### PR TITLE
support providing an IP Address when a getOffers call is made

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [8.x, 10.x, 12.x, 14.x]
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js ${{ matrix.node-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2020-06-09
+### Added
+- Support for providing an IP Address when a getOffers call is made using the request>context>geo object. [see sample usage](https://gist.github.com/jasonwaters/9a408ac65717c272efbce12d43d62c4d)
+
 ## [1.0.3] - 2019-10-10
 ### Changed
 - Minor [README](README.md) updates

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/target-nodejs-sdk",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/target-nodejs-sdk",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/target-nodejs-sdk",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Adobe Target Node.js SDK, Delivery API client",
   "main": "lib/index.js",
   "engines": {

--- a/src/helper.js
+++ b/src/helper.js
@@ -133,13 +133,19 @@ function getTargetHost(serverDomain, cluster, client, secure) {
   return `${schemePrefix}${client}.${HOST}`;
 }
 
-function createHeaders(uuidMethod = uuid) {
-  return {
+function createHeaders(ipAddress, uuidMethod = uuid) {
+  const headers = {
     "Content-Type": "application/json",
     "X-EXC-SDK": "AdobeTargetNode",
     "X-EXC-SDK-Version": version,
     "X-Request-Id": uuidMethod()
   };
+
+  if (typeof ipAddress === "string" && ipAddress.length > 0) {
+    headers["X-Forwarded-For"] = ipAddress;
+  }
+
+  return headers;
 }
 
 function getMarketingCloudVisitorId(visitor) {

--- a/src/helper.js
+++ b/src/helper.js
@@ -141,7 +141,7 @@ function createHeaders(ipAddress, uuidMethod = uuid) {
     "X-Request-Id": uuidMethod()
   };
 
-  if (typeof ipAddress === "string" && ipAddress.length > 0) {
+  if (typeof ipAddress === "string" && ipAddress.length) {
     headers["X-Forwarded-For"] = ipAddress;
   }
 
@@ -526,19 +526,15 @@ function createProperty(property = {}) {
   return undefined;
 }
 
-function getIpAddress(request) {
-  const IP_ADDRESS = /\b(?:\d{1,3}\.){3}\d{1,3}\b/g;
+function getIpAddress(request = {}) {
+  const IP_ADDRESS = /((^\s*((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))\s*$)|(^\s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(%.+)?\s*$))/g;
 
-  if (
-    request &&
-    request.context &&
-    request.context.geo &&
-    typeof request.context.geo.ipAddress === "string" &&
-    IP_ADDRESS.test(request.context.geo.ipAddress)
-  ) {
-    return request.context.geo.ipAddress;
-  }
-  return undefined;
+  const { context = {} } = request;
+  const { geo = {} } = context;
+
+  return typeof geo.ipAddress === "string" && IP_ADDRESS.test(geo.ipAddress)
+    ? geo.ipAddress
+    : undefined;
 }
 
 function createDeliveryRequest(requestParam, options) {

--- a/src/helper.js
+++ b/src/helper.js
@@ -526,6 +526,21 @@ function createProperty(property = {}) {
   return undefined;
 }
 
+function getIpAddress(request) {
+  const IP_ADDRESS = /\b(?:\d{1,3}\.){3}\d{1,3}\b/g;
+
+  if (
+    request &&
+    request.context &&
+    request.context.geo &&
+    typeof request.context.geo.ipAddress === "string" &&
+    IP_ADDRESS.test(request.context.geo.ipAddress)
+  ) {
+    return request.context.geo.ipAddress;
+  }
+  return undefined;
+}
+
 function createDeliveryRequest(requestParam, options) {
   const request = ObjectSerializer.deserialize(requestParam, "DeliveryRequest");
 
@@ -754,6 +769,7 @@ module.exports = {
   getDeviceId,
   getCluster,
   getSessionId,
+  getIpAddress,
   getTargetHost,
   extractClusterFromDeviceId,
   createHeaders,

--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,6 @@ class TargetClient {
    * @param {String} options.consumerId When stitching multiple calls, different consumerIds should be provided, optional
    * @param {Array} options.customerIds An array of Customer Ids in VisitorId-compatible format, optional
    * @param {String} options.sessionId Session Id, used for linking multiple requests, optional
-   * @param {String} options.ipAddress IP Address, used for geo location, optional
    * @param {Object} options.visitor Supply an external VisitorId instance, optional
    */
 

--- a/src/index.js
+++ b/src/index.js
@@ -64,6 +64,7 @@ class TargetClient {
    * @param {String} options.consumerId When stitching multiple calls, different consumerIds should be provided, optional
    * @param {Array} options.customerIds An array of Customer Ids in VisitorId-compatible format, optional
    * @param {String} options.sessionId Session Id, used for linking multiple requests, optional
+   * @param {String} options.ipAddress IP Address, used for geo location, optional
    * @param {Object} options.visitor Supply an external VisitorId instance, optional
    */
 

--- a/src/target.js
+++ b/src/target.js
@@ -32,6 +32,7 @@ function executeDelivery(options) {
     targetCookie,
     consumerId,
     request,
+    ipAddress,
     createDeliveryApiMethod = createDeliveryApi
   } = options;
 
@@ -42,7 +43,7 @@ function executeDelivery(options) {
   const cluster = getCluster(deviceId, targetLocationHintCookie);
   const host = getTargetHost(serverDomain, cluster, client, secure);
   const sessionId = getSessionId(cookies, options.sessionId);
-  const headers = createHeaders();
+  const headers = createHeaders(ipAddress);
 
   const requestOptions = {
     logger,

--- a/src/target.js
+++ b/src/target.js
@@ -10,6 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+const { getIpAddress } = require("./helper");
 const { parseCookies } = require("./cookies");
 const {
   getDeviceId,
@@ -32,7 +33,6 @@ function executeDelivery(options) {
     targetCookie,
     consumerId,
     request,
-    ipAddress,
     createDeliveryApiMethod = createDeliveryApi
   } = options;
 
@@ -43,7 +43,7 @@ function executeDelivery(options) {
   const cluster = getCluster(deviceId, targetLocationHintCookie);
   const host = getTargetHost(serverDomain, cluster, client, secure);
   const sessionId = getSessionId(cookies, options.sessionId);
-  const headers = createHeaders(ipAddress);
+  const headers = createHeaders(getIpAddress(request));
 
   const requestOptions = {
     logger,

--- a/test/helper.spec.js
+++ b/test/helper.spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 /*
 Copyright 2019 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
@@ -235,12 +236,28 @@ describe("Target Helper", () => {
       "X-Request-Id": "12345678-abcd-1234-efgh-000000000000"
     };
 
-    const result = createHeaders(uuidMock);
+    const result = createHeaders(undefined, uuidMock);
+    expect(result).toEqual(headers);
+  });
+
+  it("createHeaders adds X-Forwarded-For if ipAddress specified", () => {
+    const headers = {
+      "Content-Type": "application/json",
+      "X-EXC-SDK": "AdobeTargetNode",
+      "X-EXC-SDK-Version": version,
+      "X-Request-Id": "12345678-abcd-1234-efgh-000000000000",
+      "X-Forwarded-For": "123.45.67.89"
+    };
+
+    const result = createHeaders("123.45.67.89", uuidMock);
     expect(result).toEqual(headers);
   });
 
   it("createDeliveryRequest should create Delivery request", () => {
+    const context = { channel: "web", timeOffsetInMinutes: 0 };
+
     let request = {
+      context,
       execute: {
         pageLoad: {
           address: {
@@ -279,6 +296,7 @@ describe("Target Helper", () => {
     );
 
     request = {
+      context,
       property: {
         token: "at_property1"
       },
@@ -319,6 +337,7 @@ describe("Target Helper", () => {
     );
 
     request = {
+      context,
       execute: {
         mboxes: []
       },
@@ -339,6 +358,7 @@ describe("Target Helper", () => {
     );
 
     request = {
+      context,
       notifications: [
         {
           id: "id",
@@ -376,6 +396,7 @@ describe("Target Helper", () => {
     );
 
     request = {
+      context,
       notifications: [
         {
           id: "id",

--- a/test/helper.spec.js
+++ b/test/helper.spec.js
@@ -12,6 +12,7 @@ governing permissions and limitations under the License.
 */
 
 const MockDate = require("mockdate");
+const { getIpAddress } = require("../src/helper");
 const { version } = require("../package");
 const {
   ObjectSerializer,
@@ -580,5 +581,38 @@ describe("Target Helper", () => {
     expect(result).toEqual(jasmine.any(TargetDeliveryApi));
     expect(result.basePath).toEqual(URL);
     expect(result.timeout).toEqual(TIMEOUT);
+  });
+  describe("getIpAddress", () => {
+    it("returns undefined", () => {
+      expect(getIpAddress()).toBeUndefined();
+
+      expect(getIpAddress({ context: {} })).toBeUndefined();
+
+      expect(getIpAddress({ context: { geo: {} } })).toBeUndefined();
+
+      expect(
+        getIpAddress({ context: { geo: { ipAddress: "" } } })
+      ).toBeUndefined();
+
+      expect(
+        getIpAddress({ context: { geo: { ipAddress: "invalid_ip" } } })
+      ).toBeUndefined();
+    });
+
+    it("accepts valid ipv4", () => {
+      expect(
+        getIpAddress({ context: { geo: { ipAddress: "70.25.14.5" } } })
+      ).toBe("70.25.14.5");
+    });
+
+    it("accepts valid ipv6", () => {
+      expect(
+        getIpAddress({
+          context: {
+            geo: { ipAddress: "2001:cdba:0000:0000:0000:0000:3257:9652" }
+          }
+        })
+      ).toBe("2001:cdba:0000:0000:0000:0000:3257:9652");
+    });
   });
 });

--- a/test/target.spec.js
+++ b/test/target.spec.js
@@ -68,6 +68,7 @@ describe("Target Delivery API client", () => {
       targetCookie,
       consumerId: "consumer1",
       request: {
+        context: { channel: "web", timeOffsetInMinutes: 0 },
         requestId: "123",
         execute: {
           pageLoad: {}


### PR DESCRIPTION
TNT-36330

Allow an IP address to be provided in the getOffers call.  It can be added to the request>context>geo object. Full example here: https://gist.github.com/jasonwaters/9a408ac65717c272efbce12d43d62c4d

If once is specified, the `X-Forwarded-For` header is added to the delivery API request.