### PR TITLE
TNT-38898: Allocation should use TNT ID without location hint

### DIFF
--- a/packages/target-decisioning-engine/src/allocationProvider.js
+++ b/packages/target-decisioning-engine/src/allocationProvider.js
@@ -2,6 +2,12 @@ import MurmurHash3 from "imurmurhash";
 import { createUUID } from "@adobe/target-tools";
 import { getCustomerId } from "./requestProvider";
 
+function validTntId(tntId = createUUID()) {
+  // eslint-disable-next-line no-unused-vars
+  const [id, locationHint] = tntId.split(".");
+  return id;
+}
+
 /**
  *
  * @param { import("@adobe/target-tools/delivery-api-client/models/VisitorId").VisitorId } visitorId
@@ -13,8 +19,7 @@ export function getOrCreateVisitorId(visitorId) {
       visitorId.thirdPartyId ||
       getCustomerId(visitorId) ||
       visitorId.marketingCloudVisitorId ||
-      visitorId.tntId ||
-      createUUID()
+      validTntId(visitorId.tntId)
     );
   }
   return createUUID();

--- a/packages/target-decisioning-engine/src/allocationProvider.spec.js
+++ b/packages/target-decisioning-engine/src/allocationProvider.spec.js
@@ -23,6 +23,17 @@ describe("allocationProvider", () => {
     ).toEqual(8.48);
   });
 
+  it("computed allocation for tntId does not include location hint", () => {
+    expect(
+      computeAllocation(
+        "someClientId",
+        "123456",
+        { tntId: "tntId123.28_0" },
+        "salty"
+      )
+    ).toEqual(8.48);
+  });
+
   it("computes allocation for thirdPartyId", () => {
     expect(
       computeAllocation(

--- a/packages/target-decisioning-engine/src/decisionProvider.js
+++ b/packages/target-decisioning-engine/src/decisionProvider.js
@@ -33,7 +33,7 @@ const OK = 200;
 /**
  *
  * @param {import("../types/DecisioningConfig").DecisioningConfig} config
- * @param {import("../types/TargetOptions").TargetOptions} targetOptions
+ * @param {import("../types/TargetDeliveryRequest").TargetDeliveryRequest} targetOptions
  * @param {import("../types/DecisioningContext").DecisioningContext} context
  * @param { import("../types/DecisioningArtifact").DecisioningArtifact } artifact
  * @param { Object } logger

--- a/packages/target-decisioning-engine/src/index.js
+++ b/packages/target-decisioning-engine/src/index.js
@@ -20,7 +20,7 @@ export default function TargetDecisioningEngine(config) {
 
   /**
    * The get offers method
-   * @param {import("../types/TargetOptions").TargetOptions} targetOptions
+   * @param {import("../types/TargetDeliveryRequest").TargetDeliveryRequest} targetOptions
    */
   function getOffers(targetOptions) {
     let { request } = targetOptions;

--- a/packages/target-decisioning-engine/src/ruleEvaluator.js
+++ b/packages/target-decisioning-engine/src/ruleEvaluator.js
@@ -15,7 +15,7 @@ import { ACTIVITY_ID } from "./constants";
 export function ruleEvaluator(clientId, visitorId) {
   /**
    * @param {import("../types/DecisioningArtifact").Rule} rule
-   * @param { Object } context
+   * @param { import("../types/DecisioningContext").DecisioningContext } context
    * @param { 'mbox'|'view'|'pageLoad' } requestType
    * @param {import("@adobe/target-tools/delivery-api-client/models/MboxRequest").MboxRequest|import("@adobe/target-tools/delivery-api-client/models/RequestDetails").RequestDetails} requestDetail
    * @param { Array<Function> } postProcessors

--- a/packages/target-decisioning-engine/src/traceProvider.js
+++ b/packages/target-decisioning-engine/src/traceProvider.js
@@ -6,7 +6,7 @@ const byOrder = (a, b) => a.order - b.order;
 
 /**
  * @param {import("../types/DecisioningConfig").DecisioningConfig} config Options map, required
- * @param {import("../types/TargetOptions").TargetOptions} targetOptions
+ * @param {import("../types/TargetDeliveryRequest").TargetDeliveryRequest} targetOptions
  * @param { object } artifactTrace
  */
 export function TraceProvider(config, targetOptions, artifactTrace) {

--- a/packages/target-decisioning-engine/test/decisions.browser.spec.js
+++ b/packages/target-decisioning-engine/test/decisions.browser.spec.js
@@ -13,7 +13,6 @@ const TEST_CONF = {
 
 const TARGET_REQUEST = {
   id: {
-    tntId: "338e3c1e51f7416a8e1ccba4f81acea0.28_0",
     marketingCloudVisitorId: "07327024324407615852294135870030620007"
   },
   context: {

--- a/packages/target-decisioning-engine/test/decisions.geo.spec.js
+++ b/packages/target-decisioning-engine/test/decisions.geo.spec.js
@@ -35,7 +35,7 @@ describe("decisioning outcomes - geo params", () => {
     const result = await decisioning.getOffers({
       request: {
         id: {
-          tntId: "338e3c1e51f7416a8e1ccba4f81acea0.28_0"
+          thirdPartyId: "338e3c1e51f7416a8e1ccba4f81acea0.28_0"
         },
         context: {
           channel: "web",
@@ -110,7 +110,7 @@ describe("decisioning outcomes - geo params", () => {
     const result = await decisioning.getOffers({
       request: {
         id: {
-          tntId: "338e3c1e51f7416a8e1ccba4f81acea0.28_0"
+          thirdPartyId: "338e3c1e51f7416a8e1ccba4f81acea0.28_0"
         },
         context: {
           channel: "web",

--- a/packages/target-decisioning-engine/test/decisions.properties.spec.js
+++ b/packages/target-decisioning-engine/test/decisions.properties.spec.js
@@ -11,7 +11,7 @@ const TEST_CONF = {
 
 const targetRequest = {
   id: {
-    tntId: "338e3c1e51f7416a8e1ccba4f81acea0.28_0"
+    thirdPartyId: "338e3c1e51f7416a8e1ccba4f81acea0.28_0"
   },
   context: {
     channel: "web",

--- a/packages/target-decisioning-engine/test/decisions.response.tokens.spec.js
+++ b/packages/target-decisioning-engine/test/decisions.response.tokens.spec.js
@@ -38,7 +38,7 @@ describe("decisioning outcomes - response tokens", () => {
       const result = await decisioning.getOffers({
         request: {
           id: {
-            tntId: "338e3c1e51f7416a8e1ccba4f81acea0.28_0"
+            thirdPartyId: "338e3c1e51f7416a8e1ccba4f81acea0.28_0"
           },
           context: {
             channel: "web",
@@ -100,7 +100,7 @@ describe("decisioning outcomes - response tokens", () => {
       const result = await decisioning.getOffers({
         request: {
           id: {
-            tntId: "338e3c1e51f7416a8e1ccba4f81acea0.28_0"
+            thirdPartyId: "338e3c1e51f7416a8e1ccba4f81acea0.28_0"
           },
           context: {
             channel: "web",

--- a/packages/target-decisioning-engine/test/decisions.scratch.spec.js
+++ b/packages/target-decisioning-engine/test/decisions.scratch.spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable jest/no-disabled-tests */
 import * as nodeFetch from "node-fetch";
 import * as HttpsProxyAgent from "https-proxy-agent";
 

--- a/packages/target-decisioning-engine/test/decisions.views.spec.js
+++ b/packages/target-decisioning-engine/test/decisions.views.spec.js
@@ -15,7 +15,7 @@ const TEST_CONF = {
 
 const targetRequest = {
   id: {
-    tntId: "338e3c1e51f7416a8e1ccba4f81acea0.28_0"
+    thirdPartyId: "338e3c1e51f7416a8e1ccba4f81acea0.28_0"
   },
   context: {
     channel: "web",

--- a/packages/target-decisioning-engine/test/trace.spec.js
+++ b/packages/target-decisioning-engine/test/trace.spec.js
@@ -17,7 +17,7 @@ const TEST_CONF = {
 
 const targetRequest = {
   id: {
-    tntId: "338e3c1e51f7416a8e1ccba4f81acea0.28_0"
+    thirdPartyId: "338e3c1e51f7416a8e1ccba4f81acea0.28_0"
   },
   context: {
     channel: "web",
@@ -115,8 +115,7 @@ describe("trace", () => {
       ],
       profile: {
         visitorId: {
-          tntId: "338e3c1e51f7416a8e1ccba4f81acea0",
-          profileLocation: "28_0"
+          thirdPartyId: "338e3c1e51f7416a8e1ccba4f81acea0.28_0"
         }
       },
       evaluatedCampaignTargets: [
@@ -175,8 +174,7 @@ describe("trace", () => {
       ],
       profile: {
         visitorId: {
-          tntId: "338e3c1e51f7416a8e1ccba4f81acea0",
-          profileLocation: "28_0"
+          thirdPartyId: "338e3c1e51f7416a8e1ccba4f81acea0.28_0"
         }
       },
       evaluatedCampaignTargets: [
@@ -249,8 +247,7 @@ describe("trace", () => {
       ],
       profile: {
         visitorId: {
-          tntId: "338e3c1e51f7416a8e1ccba4f81acea0",
-          profileLocation: "28_0"
+          thirdPartyId: "338e3c1e51f7416a8e1ccba4f81acea0.28_0"
         }
       },
       evaluatedCampaignTargets: [
@@ -353,8 +350,7 @@ describe("trace", () => {
       ],
       profile: {
         visitorId: {
-          tntId: "338e3c1e51f7416a8e1ccba4f81acea0",
-          profileLocation: "28_0"
+          thirdPartyId: "338e3c1e51f7416a8e1ccba4f81acea0.28_0"
         }
       },
       evaluatedCampaignTargets: [

--- a/packages/target-decisioning-engine/types/TargetDeliveryRequest.d.ts
+++ b/packages/target-decisioning-engine/types/TargetDeliveryRequest.d.ts
@@ -1,7 +1,10 @@
-import {CustomerId, DeliveryRequest} from "@adobe/target-tools/delivery-api-client";
+import {
+  CustomerId,
+  DeliveryRequest,
+  Trace
+} from "@adobe/target-tools/delivery-api-client";
 
-
-export interface TargetOptions {
+export interface TargetDeliveryRequest {
   /**
    * Target Delivery Request
    */
@@ -10,35 +13,40 @@ export interface TargetOptions {
   /**
    * VisitorId cookie value
    */
-  visitorCookie?:String;
+  visitorCookie?: String;
 
   /**
    * Target cookie value
    */
-  targetCookie?:String;
+  targetCookie?: String;
 
   /**
    * Target location hint value
    */
-  targetLocationHint?:String;
+  targetLocationHint?: String;
 
   /**
    * When stitching multiple calls, different consumerIds should be provided,
    */
-  consumerId?:String;
+  consumerId?: String;
 
   /**
    * An array of Customer Ids in VisitorId-compatible format
    */
-  customerIds?:Array<CustomerId>
+  customerIds?: Array<CustomerId>;
 
   /**
    * Session Id, used for linking multiple requests
    */
-  sessionId?:String;
+  sessionId?: String;
 
   /**
    * Supply an external VisitorId instance
    */
-  visitor?:Object;
+  visitor?: Object;
+
+  /**
+   * Enables the trace. A valid authorizationToken is requried for Delivery API.
+   */
+  trace?: Trace;
 }

--- a/packages/target-nodejs-sdk/src/index.js
+++ b/packages/target-nodejs-sdk/src/index.js
@@ -148,6 +148,7 @@ export default function bootstrap(fetchApi) {
      * @param {String} options.sessionId Session Id, used for linking multiple requests, optional
      * @param {Object} options.visitor Supply an external VisitorId instance, optional
      * @param {('on-device'|'server-side'|'hybrid')} options.decisioningMethod The execution mode, defaults to remote, optional
+     * @returns Promise<TargetDeliveryResponse>
      */
     getOffers(options) {
       const error = validateGetOffersOptions(options);

--- a/packages/target-nodejs-sdk/src/index.js
+++ b/packages/target-nodejs-sdk/src/index.js
@@ -108,7 +108,7 @@ export default function bootstrap(fetchApi) {
      * @param {Number} options.pollingInterval (Local Decisioning) Polling interval in ms, default: 30000
      * @param {Number} options.maximumWaitReady (Local Decisioning) The maximum amount of time (in ms) to wait for clientReady.  Default is to wait indefinitely.
      * @param {String} options.artifactLocation (Local Decisioning) Fully qualified url to the location of the artifact, optional
-     * @param {String} options.artifactPayload (Local Decisioning) A pre-fetched artifact, optional
+     * @param {import("@adobe/target-decisioning-engine/types/DecisioningArtifact").DecisioningArtifact} options.artifactPayload (Local Decisioning) A pre-fetched artifact, optional
      * @param {Number} options.environmentId The Target environment ID, defaults to production, optional
      * @param {String} options.environment The Target environment name, defaults to production, optional
      * @param {String} options.cdnEnvironment The CDN environment name, defaults to production, optional
@@ -197,7 +197,7 @@ export default function bootstrap(fetchApi) {
       return this.getOffers({
         ...options,
         request: addMboxesToRequest(mboxNames, options.request, "execute")
-      }).then(res => AttributesProvider(mboxNames, res));
+      }).then(res => AttributesProvider(res));
     }
 
     /**

--- a/packages/target-nodejs-sdk/test/scratch.spec.js
+++ b/packages/target-nodejs-sdk/test/scratch.spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable jest/no-disabled-tests */
 const TargetClient = require("../src/index.server").default;
 
 /**

--- a/packages/target-nodejs-sdk/types/SDKResponse.d.ts
+++ b/packages/target-nodejs-sdk/types/SDKResponse.d.ts
@@ -1,4 +1,7 @@
-import {DeliveryRequest, DeliveryResponse} from "@adobe/target-tools/delivery-api-client";
+import {
+  DeliveryRequest,
+  DeliveryResponse
+} from "@adobe/target-tools/delivery-api-client";
 
 export interface Cookie {
   name: String;
@@ -6,20 +9,20 @@ export interface Cookie {
   maxAge: Number;
 }
 
-export interface ResponseStatus {
-  status: Number;
-  message: String;
+export interface ResponseMeta {
+  decisioningMethod: String;
   remoteMboxes: String[];
+  remoteViews: String[];
 }
 
-export interface OffersResponse {
-    request: DeliveryRequest;
-    response: DeliveryResponse;
-    visitorState?:Object;
-    targetCookie?:Cookie;
-    targetLocationHintCookie?:Cookie;
-    analyticsDetails?:Array<any>;
-    responseTokens?:Array<any>;
-    trace?:Array<any>;
-    status?:ResponseStatus;
+export interface TargetDeliveryResponse {
+  request: DeliveryRequest;
+  response: DeliveryResponse;
+  visitorState?: Object;
+  targetCookie?: Cookie;
+  targetLocationHintCookie?: Cookie;
+  analyticsDetails?: Array<any>;
+  responseTokens?: Array<any>;
+  trace?: Array<any>;
+  meta?: ResponseMeta;
 }

--- a/packages/target-tools/src/attributesProvider.js
+++ b/packages/target-tools/src/attributesProvider.js
@@ -31,10 +31,9 @@ function createIndexed(response) {
 }
 
 /**
- * @param {Array<String>} mboxNames A list of mbox names that contains JSON content attributes, required
  * @param { OffersResponse } offersResponse
  */
-export function AttributesProvider(mboxNames, offersResponse) {
+export function AttributesProvider(offersResponse) {
   const indexed = createIndexed(offersResponse.response);
 
   function getValue(mboxName, key) {

--- a/packages/target-tools/src/attributesProvider.js
+++ b/packages/target-tools/src/attributesProvider.js
@@ -31,7 +31,7 @@ function createIndexed(response) {
 }
 
 /**
- * @param { OffersResponse } offersResponse
+ * @param { TargetDeliveryResponse } offersResponse
  */
 export function AttributesProvider(offersResponse) {
   const indexed = createIndexed(offersResponse.response);

--- a/packages/target-tools/src/attributesProvider.spec.js
+++ b/packages/target-tools/src/attributesProvider.spec.js
@@ -108,7 +108,7 @@ const targetResponse = {
 
 describe("attributesProvider", () => {
   it("has appropriate method calls", () => {
-    const feature = AttributesProvider(["feature-flag-a"], targetResponse);
+    const feature = AttributesProvider(targetResponse);
 
     expect(typeof feature.getValue).toEqual("function");
     expect(typeof feature.asObject).toEqual("function");
@@ -119,7 +119,7 @@ describe("attributesProvider", () => {
   });
 
   it("gets value for a single mbox", () => {
-    const featureA = AttributesProvider(["feature-flag-a"], targetResponse);
+    const featureA = AttributesProvider(targetResponse);
 
     expect(featureA.getValue("feature-flag-a", "paymentExperience")).toEqual(
       "legacy"
@@ -132,7 +132,7 @@ describe("attributesProvider", () => {
       featureA.getValue("feature-flag-a", "customerFeedbackValue")
     ).toEqual(10);
 
-    const featureB = AttributesProvider(["feature-flag-b"], targetResponse);
+    const featureB = AttributesProvider(targetResponse);
 
     expect(featureB.getValue("feature-flag-b", "purchaseExperience")).toEqual(
       "beta2"
@@ -145,10 +145,7 @@ describe("attributesProvider", () => {
   });
 
   it("gets value for multiple mboxes at once", () => {
-    const features = AttributesProvider(
-      ["feature-flag-a", "feature-flag-b"],
-      targetResponse
-    );
+    const features = AttributesProvider(targetResponse);
 
     expect(features.getValue("feature-flag-a", "paymentExperience")).toEqual(
       "legacy"
@@ -172,10 +169,7 @@ describe("attributesProvider", () => {
   });
 
   it("gets as object", () => {
-    const features = AttributesProvider(
-      ["feature-flag-a", "feature-flag-b"],
-      targetResponse
-    );
+    const features = AttributesProvider(targetResponse);
 
     expect(features.asObject("feature-flag-a")).toMatchObject({
       paymentExperience: "legacy",
@@ -223,10 +217,7 @@ describe("attributesProvider", () => {
   });
 
   it("throws an error if an attribute does not exist", () => {
-    const features = AttributesProvider(
-      ["feature-flag-a", "feature-flag-b"],
-      targetResponse
-    );
+    const features = AttributesProvider(targetResponse);
 
     expect(features.getValue("feature-flag-a", "myPropertyName")).toEqual(
       new Error(ATTRIBUTE_NOT_EXIST("myPropertyName", "feature-flag-a"))


### PR DESCRIPTION
This change makes sure the `._XX_Y` location hint portion of the `tntId` is not used by the allocation provider when computing allocation.  A number of tests that were previously using `tntId` with location hint specified have been updated to use the same ID but as a `thirdPartyId`.  That ensures the tests continue to produce the same result.