### PR TITLE
TNT-40664 - fix DeliveryResponse model - notifications should be an array

### DIFF
--- a/packages/target-tools/delivery-api-client/models/DeliveryResponse.d.ts
+++ b/packages/target-tools/delivery-api-client/models/DeliveryResponse.d.ts
@@ -7,7 +7,7 @@ export interface DeliveryResponse {
     edgeHost?: string;
     execute?: ExecuteResponse;
     prefetch?: PrefetchResponse;
-    notifications?: NotificationResponse;
+    notifications?: Array<NotificationResponse>;
 }
 export declare function DeliveryResponseFromJSON(json: any): DeliveryResponse;
 export declare function DeliveryResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): DeliveryResponse;


### PR DESCRIPTION
This is a follow up PR for https://github.com/adobe/target-nodejs-sdk/pull/43
I found a bug in the DeliveryResponse model which was causing DeliveryResponse.notifictions to be a single object instead of Array.