### PR TITLE
TNT-41046 Encapsulate telemetry reporting to make it easy to switch storage layer

### DIFF
--- a/packages/target-decisioning-engine/src/decisionProvider.js
+++ b/packages/target-decisioning-engine/src/decisionProvider.js
@@ -6,8 +6,6 @@ import {
   isUndefined,
   objectWithoutUndefinedValues,
   createPerfToolInstance,
-  TelemetryProvider,
-  DECISIONING_METHOD,
   values
 } from "@adobe/target-tools";
 import { getRuleKey, hasRemoteDependency } from "./utils";
@@ -70,13 +68,6 @@ function DecisionProvider(
     visitor,
     logger,
     sendNotificationFunc,
-    telemetryEnabled
-  );
-
-  const telemetryProvider = TelemetryProvider(
-    request,
-    sendNotificationFunc,
-    DECISIONING_METHOD.ON_DEVICE,
     telemetryEnabled
   );
 
@@ -342,12 +333,11 @@ function DecisionProvider(
     prefetch: getPrefetchDecisions(commonPostProcessor)
   });
 
-  telemetryProvider.addEntry({
+  notificationProvider.addTelemetryEntry({
     execution: timingTool.timeEnd(TIMING_GET_OFFER)
   });
 
   notificationProvider.sendNotifications();
-  telemetryProvider.sendTelemetries();
 
   logger.debug(`${LOG_TAG}`, request, response);
 

--- a/packages/target-decisioning-engine/src/decisionProvider.js
+++ b/packages/target-decisioning-engine/src/decisionProvider.js
@@ -6,6 +6,8 @@ import {
   isUndefined,
   objectWithoutUndefinedValues,
   createPerfToolInstance,
+  TelemetryProvider,
+  DECISIONING_METHOD,
   values
 } from "@adobe/target-tools";
 import { getRuleKey, hasRemoteDependency } from "./utils";
@@ -68,6 +70,13 @@ function DecisionProvider(
     visitor,
     logger,
     sendNotificationFunc,
+    telemetryEnabled
+  );
+
+  const telemetryProvider = TelemetryProvider(
+    request,
+    sendNotificationFunc,
+    DECISIONING_METHOD.ON_DEVICE,
     telemetryEnabled
   );
 
@@ -333,11 +342,12 @@ function DecisionProvider(
     prefetch: getPrefetchDecisions(commonPostProcessor)
   });
 
-  notificationProvider.addTelemetryEntry({
+  telemetryProvider.addEntry({
     execution: timingTool.timeEnd(TIMING_GET_OFFER)
   });
 
   notificationProvider.sendNotifications();
+  telemetryProvider.sendTelemetries();
 
   logger.debug(`${LOG_TAG}`, request, response);
 

--- a/packages/target-decisioning-engine/src/notificationProvider.js
+++ b/packages/target-decisioning-engine/src/notificationProvider.js
@@ -29,6 +29,16 @@ function NotificationProvider(
   const timestamp = now();
   const prevEventKeys = new Set();
   let notifications = [];
+
+  function executeTelemetries(deliveryRequest, telemetryEntries) {
+    return {
+      telemetry: {
+        entries: telemetryEntries
+      },
+      ...deliveryRequest
+    };
+  }
+
   const telemetryProvider = TelemetryProvider(
     request,
     executeTelemetries,
@@ -80,15 +90,6 @@ function NotificationProvider(
    */
   function addTelemetryEntry(entry) {
     telemetryProvider.addEntry(entry);
-  }
-
-  function executeTelemetries(deliveryRequest, telemetryEntries) {
-    return {
-      telemetry: {
-        entries: telemetryEntries
-      },
-      ...deliveryRequest
-    };
   }
 
   function sendNotifications() {

--- a/packages/target-decisioning-engine/src/notificationProvider.js
+++ b/packages/target-decisioning-engine/src/notificationProvider.js
@@ -32,10 +32,10 @@ function NotificationProvider(
 
   function executeTelemetries(deliveryRequest, telemetryEntries) {
     return {
+      ...deliveryRequest,
       telemetry: {
         entries: telemetryEntries
-      },
-      ...deliveryRequest
+      }
     };
   }
 

--- a/packages/target-decisioning-engine/src/notificationProvider.js
+++ b/packages/target-decisioning-engine/src/notificationProvider.js
@@ -31,7 +31,7 @@ function NotificationProvider(
   let notifications = [];
   const telemetryProvider = TelemetryProvider(
     request,
-    undefined,
+    executeTelemetries,
     telemetryEnabled
   );
 
@@ -82,6 +82,15 @@ function NotificationProvider(
     telemetryProvider.addEntry(entry);
   }
 
+  function executeTelemetries(deliveryRequest, telemetryEntries) {
+    return {
+      telemetry: {
+        entries: telemetryEntries
+      },
+      ...deliveryRequest
+    };
+  }
+
   function sendNotifications() {
     logger.debug(
       `${LOG_TAG}.sendNotifications`,
@@ -105,7 +114,7 @@ function NotificationProvider(
         notification.request.notifications = notifications;
       }
 
-      notification.request = telemetryProvider.sendTelemetries(
+      notification.request = telemetryProvider.executeTelemetries(
         notification.request
       );
 

--- a/packages/target-decisioning-engine/src/notificationProvider.js
+++ b/packages/target-decisioning-engine/src/notificationProvider.js
@@ -4,9 +4,9 @@ import {
   noop,
   now,
   MetricType,
+  TelemetryProvider,
   isFunction
 } from "@adobe/target-tools";
-import { TelemetryProvider } from "../../target-tools/src";
 import { LOG_PREFIX } from "./constants";
 
 const LOG_TAG = `${LOG_PREFIX}.NotificationProvider`;

--- a/packages/target-tools/src/index.js
+++ b/packages/target-tools/src/index.js
@@ -81,7 +81,7 @@ export { getFetchWithRetry, getFetchApi } from "./networking";
 
 export { AttributesProvider } from "./attributesProvider";
 export { EventProvider } from "./eventProvider";
-export { default as TelemetryProvider } from "./telemetryProvider";
+export { TelemetryProvider } from "./telemetryProvider";
 
 export {
   browserFromUserAgent,

--- a/packages/target-tools/src/index.js
+++ b/packages/target-tools/src/index.js
@@ -81,6 +81,7 @@ export { getFetchWithRetry, getFetchApi } from "./networking";
 
 export { AttributesProvider } from "./attributesProvider";
 export { EventProvider } from "./eventProvider";
+export { default as TelemetryProvider } from "./telemetryProvider";
 
 export {
   browserFromUserAgent,

--- a/packages/target-tools/src/telemetryProvider.js
+++ b/packages/target-tools/src/telemetryProvider.js
@@ -1,6 +1,5 @@
 import { now } from "./lodash";
 import { DECISIONING_METHOD } from "./enums";
-import { noop } from "./utils";
 
 /**
  * The get TelemetryProvider initialization method
@@ -8,7 +7,6 @@ import { noop } from "./utils";
  */
 function TelemetryProvider(
   request,
-  sendTelemetriesFunc = noop,
   decisioningMethod = DECISIONING_METHOD.ON_DEVICE,
   telemetryEnabled = true
 ) {
@@ -34,18 +32,29 @@ function TelemetryProvider(
     });
   }
 
-  function sendTelemetries() {
+  function sendTelemetries(deliveryRequest) {
     if (telemetryEntries.length > 0) {
-      setTimeout(() => {
-        sendTelemetriesFunc.call(null, telemetryEntries);
-        telemetryEntries = [];
-      }, 0);
+      const deliveryRequestWithTelemetry = {
+        ...deliveryRequest,
+        telemetry: {
+          entries: telemetryEntries
+        }
+      };
+      telemetryEntries = [];
+
+      return deliveryRequestWithTelemetry;
     }
+    return deliveryRequest;
+  }
+
+  function getEntries() {
+    return telemetryEntries;
   }
 
   return {
     addEntry,
-    sendTelemetries
+    sendTelemetries,
+    getEntries
   };
 }
 

--- a/packages/target-tools/src/telemetryProvider.js
+++ b/packages/target-tools/src/telemetryProvider.js
@@ -1,0 +1,52 @@
+import { now } from "./lodash";
+import { DECISIONING_METHOD } from "./enums";
+import { noop } from "./utils";
+
+/**
+ * The get TelemetryProvider initialization method
+ * @param {function} sendTelemetriesFunc function used to send the telemetries, required
+ */
+function TelemetryProvider(
+  request,
+  sendTelemetriesFunc = noop,
+  decisioningMethod = DECISIONING_METHOD.ON_DEVICE,
+  telemetryEnabled = true
+) {
+  const { requestId } = request;
+  const timestamp = now();
+  let telemetryEntries = [];
+
+  /**
+   * @param {import("@adobe/target-tools/delivery-api-client/models/TelemetryEntry").TelemetryEntry} entry
+   */
+  function addEntry(entry) {
+    if (!telemetryEnabled) {
+      return;
+    }
+
+    telemetryEntries.push({
+      requestId,
+      timestamp,
+      features: {
+        decisioningMethod
+      },
+      ...entry
+    });
+  }
+
+  function sendTelemetries() {
+    if (telemetryEntries.length > 0) {
+      setTimeout(() => {
+        sendTelemetriesFunc.call(null, telemetryEntries);
+        telemetryEntries = [];
+      }, 0);
+    }
+  }
+
+  return {
+    addEntry,
+    sendTelemetries
+  };
+}
+
+export default TelemetryProvider;

--- a/packages/target-tools/src/telemetryProvider.js
+++ b/packages/target-tools/src/telemetryProvider.js
@@ -10,7 +10,7 @@ import { DECISIONING_METHOD } from "./enums";
  */
 export function TelemetryProvider(
   request,
-  executeTelemetriesFunc = noop,
+  executeTelemetriesFunc,
   telemetryEnabled = true,
   decisioningMethod = DECISIONING_METHOD.ON_DEVICE
 ) {

--- a/packages/target-tools/src/telemetryProvider.js
+++ b/packages/target-tools/src/telemetryProvider.js
@@ -1,7 +1,6 @@
 /* eslint-disable import/prefer-default-export */
 
 import { now } from "./lodash";
-import { noop } from "./utils";
 import { DECISIONING_METHOD } from "./enums";
 
 /**

--- a/packages/target-tools/src/telemetryProvider.spec.js
+++ b/packages/target-tools/src/telemetryProvider.spec.js
@@ -1,0 +1,58 @@
+import TelemetryProvider from "./telemetryProvider";
+
+describe("TelemetryProvider", () => {
+  const TARGET_REQUEST = {
+    requestId: "123456"
+  };
+
+  const TARGET_TELEMETRY_ENTRY = {};
+
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  it("adds an entry", () => {
+    const mockSend = jest.fn();
+
+    const provider = TelemetryProvider(
+      TARGET_REQUEST,
+      mockSend,
+      undefined,
+      true
+    );
+
+    provider.addEntry(TARGET_TELEMETRY_ENTRY);
+
+    provider.sendTelemetries();
+    jest.runAllTimers();
+    console.log(mockSend.mock.calls);
+    expect(mockSend.mock.calls.length).toBe(1);
+    expect(mockSend.mock.calls[0].length).toEqual(1);
+    expect(mockSend.mock.calls[0][0][0]).toEqual(
+      expect.objectContaining({
+        requestId: expect.any(String),
+        timestamp: expect.any(Number),
+        features: {
+          decisioningMethod: expect.any(String)
+        }
+      })
+    );
+  });
+
+  it("disables telemetries", () => {
+    const mockSend = jest.fn();
+
+    const provider = TelemetryProvider(
+      TARGET_REQUEST,
+      mockSend,
+      undefined,
+      false
+    );
+
+    provider.addEntry(TARGET_TELEMETRY_ENTRY);
+    provider.sendTelemetries();
+    jest.runAllTimers();
+
+    expect(mockSend.mock.calls.length).toBe(0);
+  });
+});

--- a/packages/target-tools/src/telemetryProvider.spec.js
+++ b/packages/target-tools/src/telemetryProvider.spec.js
@@ -1,4 +1,4 @@
-import TelemetryProvider from "./telemetryProvider";
+import { TelemetryProvider } from "./telemetryProvider";
 
 describe("TelemetryProvider", () => {
   const TARGET_REQUEST = {
@@ -19,12 +19,10 @@ describe("TelemetryProvider", () => {
     const provider = TelemetryProvider(TARGET_REQUEST, mockExecute);
 
     provider.addEntry(TARGET_TELEMETRY_ENTRY);
-    const request = provider.executeTelemetries(TARGET_REQUEST);
+    provider.executeTelemetries(TARGET_REQUEST);
 
-    expect(request).toHaveProperty("telemetry");
-    expect(request.telemetry).toHaveProperty("entries");
-    expect(request.telemetry.entries.length).toEqual(1);
-    expect(request.telemetry.entries[0]).toEqual(
+    expect(mockExecute.mock.calls.length).toBe(1);
+    expect(mockExecute.mock.calls[0][1][0]).toEqual(
       expect.objectContaining({
         requestId: expect.any(String),
         timestamp: expect.any(Number),
@@ -39,11 +37,17 @@ describe("TelemetryProvider", () => {
   });
 
   it("disables telemetries", () => {
-    const provider = TelemetryProvider(TARGET_REQUEST, undefined, false);
+    const mockExecute = jest.fn();
+
+    const provider = TelemetryProvider(TARGET_REQUEST, mockExecute, false);
 
     provider.addEntry(TARGET_TELEMETRY_ENTRY);
-    const request = provider.sendTelemetries(TARGET_REQUEST);
 
-    expect(request).not.toHaveProperty("telemetry");
+    const entries = provider.getEntries();
+    expect(entries.length).toEqual(0);
+
+    provider.executeTelemetries(TARGET_REQUEST);
+
+    expect(mockExecute.mock.calls.length).toBe(0);
   });
 });

--- a/packages/target-tools/src/telemetryProvider.spec.js
+++ b/packages/target-tools/src/telemetryProvider.spec.js
@@ -1,5 +1,4 @@
 import { TelemetryProvider } from "./telemetryProvider";
-import * as utils from "./utils";
 
 describe("TelemetryProvider", () => {
   const TARGET_REQUEST = {
@@ -28,20 +27,10 @@ describe("TelemetryProvider", () => {
         }
       })
     );
+    expect(mockExecute.mock.calls[0][1][0].execution).toBe(1);
 
     const entries = provider.getEntries();
     expect(entries.length).toEqual(0);
-  });
-
-  it("execute function undefined", () => {
-    utils.noop = jest.fn();
-
-    const provider = TelemetryProvider(TARGET_REQUEST);
-
-    provider.addEntry(TARGET_TELEMETRY_ENTRY);
-    provider.executeTelemetries(TARGET_REQUEST);
-
-    expect(utils.noop.mock.calls.length).toBe(1);
   });
 
   it("disables telemetries", () => {

--- a/packages/target-tools/src/telemetryProvider.spec.js
+++ b/packages/target-tools/src/telemetryProvider.spec.js
@@ -28,7 +28,6 @@ describe("TelemetryProvider", () => {
         execution: 1
       })
     );
-    expect(mockExecute.mock.calls[0][1][0].execution).toBe(1);
 
     const entries = provider.getEntries();
     expect(entries.length).toEqual(0);

--- a/packages/target-tools/src/telemetryProvider.spec.js
+++ b/packages/target-tools/src/telemetryProvider.spec.js
@@ -1,4 +1,5 @@
 import { TelemetryProvider } from "./telemetryProvider";
+import * as utils from "./utils";
 
 describe("TelemetryProvider", () => {
   const TARGET_REQUEST = {
@@ -8,10 +9,6 @@ describe("TelemetryProvider", () => {
   const TARGET_TELEMETRY_ENTRY = {
     execution: 1
   };
-
-  beforeAll(() => {
-    jest.useFakeTimers();
-  });
 
   it("adds an entry", () => {
     const mockExecute = jest.fn();
@@ -34,6 +31,17 @@ describe("TelemetryProvider", () => {
 
     const entries = provider.getEntries();
     expect(entries.length).toEqual(0);
+  });
+
+  it("execute function undefined", () => {
+    utils.noop = jest.fn();
+
+    const provider = TelemetryProvider(TARGET_REQUEST);
+
+    provider.addEntry(TARGET_TELEMETRY_ENTRY);
+    provider.executeTelemetries(TARGET_REQUEST);
+
+    expect(utils.noop.mock.calls.length).toBe(1);
   });
 
   it("disables telemetries", () => {

--- a/packages/target-tools/src/telemetryProvider.spec.js
+++ b/packages/target-tools/src/telemetryProvider.spec.js
@@ -24,7 +24,8 @@ describe("TelemetryProvider", () => {
         timestamp: expect.any(Number),
         features: {
           decisioningMethod: expect.any(String)
-        }
+        },
+        execution: 1
       })
     );
     expect(mockExecute.mock.calls[0][1][0].execution).toBe(1);

--- a/packages/target-tools/src/telemetryProvider.spec.js
+++ b/packages/target-tools/src/telemetryProvider.spec.js
@@ -25,7 +25,6 @@ describe("TelemetryProvider", () => {
 
     provider.sendTelemetries();
     jest.runAllTimers();
-    console.log(mockSend.mock.calls);
     expect(mockSend.mock.calls.length).toBe(1);
     expect(mockSend.mock.calls[0].length).toEqual(1);
     expect(mockSend.mock.calls[0][0][0]).toEqual(

--- a/packages/target-tools/src/telemetryProvider.spec.js
+++ b/packages/target-tools/src/telemetryProvider.spec.js
@@ -14,10 +14,12 @@ describe("TelemetryProvider", () => {
   });
 
   it("adds an entry", () => {
-    const provider = TelemetryProvider(TARGET_REQUEST, undefined, true);
+    const mockExecute = jest.fn();
+
+    const provider = TelemetryProvider(TARGET_REQUEST, mockExecute);
 
     provider.addEntry(TARGET_TELEMETRY_ENTRY);
-    const request = provider.sendTelemetries(TARGET_REQUEST);
+    const request = provider.executeTelemetries(TARGET_REQUEST);
 
     expect(request).toHaveProperty("telemetry");
     expect(request.telemetry).toHaveProperty("entries");
@@ -31,6 +33,9 @@ describe("TelemetryProvider", () => {
         }
       })
     );
+
+    const entries = provider.getEntries();
+    expect(entries.length).toEqual(0);
   });
 
   it("disables telemetries", () => {

--- a/packages/target-tools/src/telemetryProvider.spec.js
+++ b/packages/target-tools/src/telemetryProvider.spec.js
@@ -5,29 +5,24 @@ describe("TelemetryProvider", () => {
     requestId: "123456"
   };
 
-  const TARGET_TELEMETRY_ENTRY = {};
+  const TARGET_TELEMETRY_ENTRY = {
+    execution: 1
+  };
 
   beforeAll(() => {
     jest.useFakeTimers();
   });
 
   it("adds an entry", () => {
-    const mockSend = jest.fn();
-
-    const provider = TelemetryProvider(
-      TARGET_REQUEST,
-      mockSend,
-      undefined,
-      true
-    );
+    const provider = TelemetryProvider(TARGET_REQUEST, undefined, true);
 
     provider.addEntry(TARGET_TELEMETRY_ENTRY);
+    const request = provider.sendTelemetries(TARGET_REQUEST);
 
-    provider.sendTelemetries();
-    jest.runAllTimers();
-    expect(mockSend.mock.calls.length).toBe(1);
-    expect(mockSend.mock.calls[0].length).toEqual(1);
-    expect(mockSend.mock.calls[0][0][0]).toEqual(
+    expect(request).toHaveProperty("telemetry");
+    expect(request.telemetry).toHaveProperty("entries");
+    expect(request.telemetry.entries.length).toEqual(1);
+    expect(request.telemetry.entries[0]).toEqual(
       expect.objectContaining({
         requestId: expect.any(String),
         timestamp: expect.any(Number),
@@ -39,19 +34,11 @@ describe("TelemetryProvider", () => {
   });
 
   it("disables telemetries", () => {
-    const mockSend = jest.fn();
-
-    const provider = TelemetryProvider(
-      TARGET_REQUEST,
-      mockSend,
-      undefined,
-      false
-    );
+    const provider = TelemetryProvider(TARGET_REQUEST, undefined, false);
 
     provider.addEntry(TARGET_TELEMETRY_ENTRY);
-    provider.sendTelemetries();
-    jest.runAllTimers();
+    const request = provider.sendTelemetries(TARGET_REQUEST);
 
-    expect(mockSend.mock.calls.length).toBe(0);
+    expect(request).not.toHaveProperty("telemetry");
   });
 });


### PR DESCRIPTION
## Description

Telemetry related logic was moved out of the target-decisioning-engine notificationProvider and into target-tools telemetryProvider.

The TelemetryProvider stores telemetry entries, and can add them to a DeliveryRequest.

Currently the implementation was kept relatively the same. The NotificationProvider has a TelemetryProvider, using it to store entries, and to add telemetries before sending notifications.

## Related Issue

[Jira Ticket](https://jira.corp.adobe.com/browse/TNT-41046)

## Motivation and Context

Description from Jira Ticket:

Currently telemetry reporting is done through Delivery API and makes its way into Prometheus; reporting and storage are tightly coupled in the SDKs.  We should decouple them and create an abstract storage service in case we switch to a different storage layer in the future.

## How Has This Been Tested?

Tests were added for the new Telemetry Provider, just ensuring it stores entries and adds them to a request.
Tests were run with `npm run test` and written using jest.

This implementation will impact how the notification provider stores telemetry entries by encapsulating telemetry related logic in a separate class.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html). I'm an intern so I need to contact someone about resolving this.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
