### PR TITLE
TNT-41216 Add missing export

### DIFF
--- a/packages/target-tools/src/index.browser.js
+++ b/packages/target-tools/src/index.browser.js
@@ -55,7 +55,8 @@ export {
   getPropertyToken,
   timeLimitExceeded,
   isValidIpAddress,
-  whenReady
+  whenReady,
+  executeTelemetries
 } from "./utils";
 
 export { getLogger } from "./logging";


### PR DESCRIPTION
## Description

`exportTelemetries` was missing as an export to `index.browser.js` in PR for [TNT-41216](https://github.com/adobe/target-nodejs-sdk/pull/56).

## Related Issue

- Fixes bug in [TNT-41216 PR](https://github.com/adobe/target-nodejs-sdk/pull/56).
- [Jira Ticket](https://jira.corp.adobe.com/browse/TNT-41216)
