### PR TITLE
[TNT-41651] download property-specific artifact if a token is specified

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x]
+        node-version: [12.x, 14.x, 16.x]
     steps:
       - uses: actions/checkout@master
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x]
+        node-version: [10.x, 12.x, 14.x, 16.x]
     steps:
       - uses: actions/checkout@master
       - name: Use Node.js ${{ matrix.node-version }}

--- a/packages/target-decisioning-engine/src/artifactProvider.spec.js
+++ b/packages/target-decisioning-engine/src/artifactProvider.spec.js
@@ -414,26 +414,12 @@ describe("determineArtifactLocation", () => {
     );
   });
 
-  it("does not add property token by default", () => {
+  it("adds property token if provided", () => {
     expect(
       determineArtifactLocation({
         client: "someClientId",
         propertyToken: "xyz-123-abc"
       })
-    ).toEqual(
-      `https://${CDN_BASE_PROD}/someClientId/production/v${SUPPORTED_ARTIFACT_MAJOR_VERSION}/rules.json`
-    );
-  });
-
-  it("can be forced to add property token", () => {
-    expect(
-      determineArtifactLocation(
-        {
-          client: "someClientId",
-          propertyToken: "xyz-123-abc"
-        },
-        true
-      )
     ).toEqual(
       `https://${CDN_BASE_PROD}/someClientId/production/v${SUPPORTED_ARTIFACT_MAJOR_VERSION}/xyz-123-abc/rules.json`
     );

--- a/packages/target-decisioning-engine/src/utils.js
+++ b/packages/target-decisioning-engine/src/utils.js
@@ -7,7 +7,6 @@ import {
   getViewNames,
   hasRequestedViews,
   includes,
-  isBrowser,
   isDefined,
   isObject,
   isString,
@@ -18,14 +17,14 @@ import {
 
 import Messages from "./messages";
 import {
-  ARTIFACT_FORMAT_BINARY,
   ARTIFACT_FILENAME,
+  ARTIFACT_FORMAT_BINARY,
+  ARTIFACT_FORMAT_DEFAULT,
   ARTIFACT_FORMAT_JSON,
+  ARTIFACT_FORMATS,
   CDN_BASE,
   REGEX_ARTIFACT_FILENAME_BINARY,
-  SUPPORTED_ARTIFACT_MAJOR_VERSION,
-  ARTIFACT_FORMAT_DEFAULT,
-  ARTIFACT_FORMATS
+  SUPPORTED_ARTIFACT_MAJOR_VERSION
 } from "./constants";
 
 /**
@@ -220,10 +219,7 @@ export function getGeoLookupPath(config) {
  * @param {import("../types/DecisioningConfig").DecisioningConfig} config Options map, required
  * @param {Boolean} addPropertyToken
  */
-export function determineArtifactLocation(
-  config,
-  addPropertyToken = isBrowser()
-) {
+export function determineArtifactLocation(config) {
   const { client, propertyToken, artifactFormat, artifactLocation } = config;
   if (isString(artifactLocation)) {
     return artifactLocation;
@@ -236,7 +232,7 @@ export function determineArtifactLocation(
     client,
     targetEnvironment,
     `v${SUPPORTED_ARTIFACT_MAJOR_VERSION}`,
-    addPropertyToken ? propertyToken : undefined,
+    isDefined(propertyToken) ? propertyToken : undefined,
     getArtifactFileName(artifactFormat)
   ]
     .filter(value => isDefined(value))


### PR DESCRIPTION

## Description

Prior to this change, the node SDK always downloaded the "global" rules.json file, so that it could answer calls for any property -- even if the SDK had been configured with a property token on init.  But this change makes it so the SDK downloads the property-specific artifact only if one is specified on init.  This helps for those with server-side constraints where large artifact sizes are not ideal.


## Related Issue

https://jira.corp.adobe.com/browse/TNT-41651

## How Has This Been Tested?

added a test case `adds property token if provided`

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
