### PR TITLE
TNT-41928 Implement server-side A4T & AAM request mapping

### DIFF
--- a/packages/target-tools/src/transforms/requestTransform.spec.js
+++ b/packages/target-tools/src/transforms/requestTransform.spec.js
@@ -750,6 +750,68 @@ describe("targetDeliveryToAepEdgeRequest", () => {
     });
   });
 
+  it("server-side A4T", () => {
+    expect(
+      targetDeliveryToAepEdgeRequest({
+        ...basicRequest,
+        deliveryRequest: {
+          experienceCloud: {
+            analytics: {
+              logging: "server_side",
+              supplementalDataId: "sdid12345",
+              trackingServer: "trk.test.com",
+              trackingServerSecure: "secure.trk.test.com"
+            },
+            audienceManager: {
+              locationHint: 8,
+              blob: "aamblob1234567"
+            }
+          },
+          execute: {
+            pageLoad: {
+              address: "https://adobe.com"
+            }
+          }
+        }
+      })
+    ).toMatchObject({
+      edgeRequest: {
+        events: [
+          {
+            query: {
+              personalization: {
+                schemas: [
+                  "https://ns.adobe.com/personalization/html-content-item",
+                  "https://ns.adobe.com/personalization/json-content-item",
+                  "https://ns.adobe.com/personalization/redirect-item",
+                  "https://ns.adobe.com/personalization/dom-action"
+                ],
+                decisionScopes: ["__view__"]
+              }
+            },
+            xdm: {
+              timestamp: expect.any(Date),
+              implementationDetails: {
+                name: "https://ns.adobe.com/experience/aep-edge-nodejs-sdk",
+                version: expect.any(String),
+                environment: expect.any(String)
+              }
+            },
+            meta: {
+              personalization: {
+                analyticsSupplementalDataId: "sdid12345",
+                analyticsTrackingServer: "trk.test.com",
+                analyticsTrackingServerSecure: "secure.trk.test.com",
+                aamLocationHint: 8,
+                aamBlob: "aamblob1234567"
+              }
+            }
+          }
+        ]
+      }
+    });
+  });
+
   it("requests", async () => {
     expect.assertions(4);
     const configuration = new Configuration({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Map server-side A4T & AAM params to Konductor events meta

TNT-41928 Support server-side Analytics logging
TNT-41930 Support AAM params

Related aep-edge-nodejs-sdk PR https://github.com/adobe/aep-edge-nodejs-sdk/pull/3
**Note:** Changes from the aep-edge-nodejs-sdk PR must be merged in the local copy in order to ensure proper serialization of newly added meta fields

## Related Issue
https://jira.corp.adobe.com/browse/TNT-41928
https://jira.corp.adobe.com/browse/TNT-41930
