### PR TITLE
TNT-41240 - Use custom http fetch impl to collect request timings 

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,6 @@ Production dependencies include:
   "@adobe-mcid/visitor-js-server": {
     "version": "2.0.0",
     "license": "Adobe Proprietary license"
-  },
-  "node-fetch": {
-    "version": "2.6.1",
-    "license": "MIT",
-    "repository": "https://github.com/node-fetch/node-fetch"
   }
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-reports": "^3.0.1",
         "lerna": "^3.20.2",
-        "node-fetch": "^2.6.1",
         "prettier": "^2.1.2",
         "pretty-quick": "^3.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "istanbul-lib-report": "^3.0.0",
     "istanbul-reports": "^3.0.1",
     "lerna": "^3.20.2",
-    "node-fetch": "^2.6.1",
     "prettier": "^2.1.2",
     "pretty-quick": "^3.1.0"
   }

--- a/packages/target-decisioning-engine/package.json
+++ b/packages/target-decisioning-engine/package.json
@@ -51,7 +51,6 @@
     "jest": "^26.6.3",
     "jest-fetch-mock": "^3.0.3",
     "mockdate": "^2.0.5",
-    "node-fetch": "^2.6.1",
     "prettier": "^2.1.2",
     "rimraf": "^3.0.2",
     "rollup": "^1.17.0",

--- a/packages/target-decisioning-engine/test/decisions.scratch.spec.js
+++ b/packages/target-decisioning-engine/test/decisions.scratch.spec.js
@@ -1,6 +1,6 @@
 /* eslint-disable jest/no-disabled-tests */
-import * as nodeFetch from "node-fetch";
 import * as HttpsProxyAgent from "https-proxy-agent";
+import { defaultFetch } from "@adobe/target-tools";
 
 import TargetDecisioningEngine from "../src";
 
@@ -11,11 +11,10 @@ import TargetDecisioningEngine from "../src";
 function getFetchWithProxy() {
   process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
 
-  const fetch = nodeFetch.default;
   const ProxyAgent = HttpsProxyAgent.default;
 
   return (url, options) => {
-    return fetch(url, {
+    return defaultFetch(url, {
       ...options,
       agent: new ProxyAgent("http://127.0.0.1:9090")
     });
@@ -25,7 +24,7 @@ function getFetchWithProxy() {
 const TEST_CONF = {
   client: "targettesting",
   organizationId: "74F652E95F1B16FE0A495C92@AdobeOrg",
-  fetchApi: nodeFetch.default, // getFetchWithProxy(),
+  fetchApi: defaultFetch, // getFetchWithProxy(),
   pollingInterval: 0,
   logger: {
     // eslint-disable-next-line no-console

--- a/packages/target-decisioning-engine/test/decisions.scratch.spec.js
+++ b/packages/target-decisioning-engine/test/decisions.scratch.spec.js
@@ -1,8 +1,9 @@
 /* eslint-disable jest/no-disabled-tests */
 import * as HttpsProxyAgent from "https-proxy-agent";
-import { defaultFetch } from "@adobe/target-tools";
-
+import { getFetchWithTelemetry } from "@adobe/target-tools";
 import TargetDecisioningEngine from "../src";
+
+const fetchWithTelemetry = getFetchWithTelemetry();
 
 /**
  * Use this method to proxy requests to Proxyman or Charles Proxy
@@ -14,7 +15,7 @@ function getFetchWithProxy() {
   const ProxyAgent = HttpsProxyAgent.default;
 
   return (url, options) => {
-    return defaultFetch(url, {
+    return fetchWithTelemetry(url, {
       ...options,
       agent: new ProxyAgent("http://127.0.0.1:9090")
     });
@@ -24,7 +25,7 @@ function getFetchWithProxy() {
 const TEST_CONF = {
   client: "targettesting",
   organizationId: "74F652E95F1B16FE0A495C92@AdobeOrg",
-  fetchApi: defaultFetch, // getFetchWithProxy(),
+  fetchApi: fetchWithTelemetry, // getFetchWithProxy(),
   pollingInterval: 0,
   logger: {
     // eslint-disable-next-line no-console

--- a/packages/target-nodejs-sdk/package.json
+++ b/packages/target-nodejs-sdk/package.json
@@ -85,7 +85,6 @@
     "fast-text-encoding": "^1.0.3",
     "form-data": "^3.0.0",
     "http-status-codes": "^1.4.0",
-    "node-fetch": "^2.6.1",
     "whatwg-fetch": "^3.0.0"
   }
 }

--- a/packages/target-nodejs-sdk/src/helper.js
+++ b/packages/target-nodejs-sdk/src/helper.js
@@ -531,7 +531,7 @@ function createLocalDeliveryApi(
   visitor,
   targetLocationHint
 ) {
-  return {
+  const localDeliveryApi = {
     // eslint-disable-next-line no-unused-vars
     execute: (organizationId, sessionId, deliveryRequest, atjsVersion) => {
       if (isUndefined(decisioningEngine)) {
@@ -547,6 +547,8 @@ function createLocalDeliveryApi(
     },
     decisioningMethod: DECISIONING_METHOD.ON_DEVICE
   };
+  localDeliveryApi.withPostMiddleware = () => localDeliveryApi;
+  return localDeliveryApi;
 }
 
 function createBeaconDeliveryApi(configuration) {

--- a/packages/target-nodejs-sdk/src/index.server.js
+++ b/packages/target-nodejs-sdk/src/index.server.js
@@ -1,9 +1,8 @@
 import FormData from "form-data";
 import { URLSearchParams } from "url";
-import * as nodeFetch from "node-fetch";
 import "fast-text-encoding";
 
-import { isDefined } from "@adobe/target-tools";
+import { defaultFetch, isDefined } from "@adobe/target-tools";
 import bootstrap from "./index";
 
 global.FormData = FormData;
@@ -11,7 +10,7 @@ global.URLSearchParams = URLSearchParams;
 
 const TargetClient = bootstrap(
   // eslint-disable-next-line no-undef
-  isDefined(global.fetch) ? global.fetch : nodeFetch.default
+  isDefined(global.fetch) ? global.fetch : defaultFetch
 );
 
 export default TargetClient.default || TargetClient;

--- a/packages/target-nodejs-sdk/src/index.server.js
+++ b/packages/target-nodejs-sdk/src/index.server.js
@@ -2,7 +2,7 @@ import FormData from "form-data";
 import { URLSearchParams } from "url";
 import "fast-text-encoding";
 
-import { defaultFetch, isDefined } from "@adobe/target-tools";
+import { getFetchWithTelemetry, isDefined } from "@adobe/target-tools";
 import bootstrap from "./index";
 
 global.FormData = FormData;
@@ -10,7 +10,7 @@ global.URLSearchParams = URLSearchParams;
 
 const TargetClient = bootstrap(
   // eslint-disable-next-line no-undef
-  isDefined(global.fetch) ? global.fetch : defaultFetch
+  isDefined(global.fetch) ? global.fetch : getFetchWithTelemetry()
 );
 
 export default TargetClient.default || TargetClient;

--- a/packages/target-nodejs-sdk/test/target.spec.js
+++ b/packages/target-nodejs-sdk/test/target.spec.js
@@ -48,13 +48,15 @@ function spyOnAllFunctions(obj) {
 describe("Target Delivery API client", () => {
   beforeAll(() => {
     MockDate.set("2019-10-06");
-    createDeliveryApiSpy = jest.fn(() => ({
+    const mockDeliveryApi = {
       execute: () =>
         Promise.resolve({
           status: 200,
           body: "responseBody"
         })
-    }));
+    };
+    mockDeliveryApi.withPostMiddleware = () => mockDeliveryApi;
+    createDeliveryApiSpy = jest.fn(() => mockDeliveryApi);
     spyOnAllFunctions(EMPTY_VISITOR);
     spyOnAllFunctions(testLogger);
   });
@@ -122,9 +124,11 @@ describe("Target Delivery API client", () => {
     expect(EMPTY_VISITOR.getState.mock.calls.length).toBe(3);
     expect(testLogger.debug.mock.calls.length).toBe(2);
 
-    createDeliveryApiSpy = jest.fn(() => ({
+    const mockDeliveryApi = {
       execute: () => Promise.resolve(undefined)
-    }));
+    };
+    mockDeliveryApi.withPostMiddleware = () => mockDeliveryApi;
+    createDeliveryApiSpy = jest.fn(() => mockDeliveryApi);
     options.createDeliveryApiMethod = createDeliveryApiSpy;
 
     const result = await target.executeDelivery(options, telemetryProvider);

--- a/packages/target-tools/src/fetchWithTelemetry.js
+++ b/packages/target-tools/src/fetchWithTelemetry.js
@@ -1,0 +1,281 @@
+/* eslint no-param-reassign: ['error', { 'props': false }] */
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import https from "https";
+
+const DEFAULT_AGENT = new https.Agent({
+  keepAlive: true
+});
+const GET = "GET";
+const POST = "POST";
+const SECURE_PROTOCOL = "https:";
+const UTF8_ENCODING = "utf8";
+const ERROR = "error";
+const PARSE_ERROR = "parse_error";
+const ABORT = "abort";
+const TIMEOUT = "timeout";
+const ABORTED = "Request aborted";
+const TIMED_OUT = "Request timed out";
+
+const RESPONSE_EVENT = "response";
+const DATA_EVENT = "data";
+const END_EVENT = "end";
+const ABORT_EVENT = "abort";
+const TIMEOUT_EVENT = "timeout";
+const ERROR_EVENT = "error";
+const SOCKET_EVENT = "socket";
+const LOOKUP_EVENT = "lookup";
+const CONNECT_EVENT = "connect";
+const SECURE_CONNECT_EVENT = "secureConnect";
+
+const NS_PER_SEC = 1e9;
+const MS_PER_NS = 1e6;
+
+const OK = 200;
+const NOT_MODIFIED = 304;
+
+function getNanoSeconds() {
+  const hr = process.hrtime();
+
+  return hr[0] * NS_PER_SEC + hr[1];
+}
+
+const UP_TIME = process.uptime() * NS_PER_SEC;
+const MODULE_LOAD_TIME = getNanoSeconds();
+const NODE_LOAD_TIME = MODULE_LOAD_TIME - UP_TIME;
+
+function now() {
+  return (getNanoSeconds() - NODE_LOAD_TIME) / MS_PER_NS;
+}
+
+function creatError(status, err, timings, statusCode) {
+  const message = typeof err === "object" ? JSON.stringify(err) : err;
+  return { status, message, timings, statusCode };
+}
+
+function makeHeadersFetchCompatible(headers = {}) {
+  return {
+    get: headerName => headers[headerName.toLowerCase()]
+  };
+}
+
+function createResponse(data, response, timings, status, headers) {
+  return {
+    data,
+    response,
+    timings,
+    status,
+    headers: makeHeadersFetchCompatible(headers),
+    ok: status === OK,
+    json: () => Promise.resolve(data)
+  };
+}
+
+/**
+ * We need to maintain cross-compatibility with browser fetch impl,
+ * so this returns a response object with the same interface.
+ * @return {import("../types/FetchResponse").FetchResponse}
+ */
+function createSuccess(data, response, timings, status, headers) {
+  const fetchResponse = createResponse(
+    data,
+    response,
+    timings,
+    status,
+    headers
+  );
+  // eslint-disable-next-line prefer-rest-params
+  fetchResponse.clone = () => createResponse(...arguments);
+  return fetchResponse;
+}
+
+function getTimings(timings, responseContent) {
+  if (!timings.socket) {
+    timings.socket = 0;
+  }
+
+  if (!timings.lookup) {
+    timings.lookup = timings.socket;
+  }
+
+  if (!timings.connect) {
+    timings.connect = timings.lookup;
+  }
+
+  if (!timings.secureConnect) {
+    timings.secureConnect = timings.connect;
+  }
+
+  if (!timings.response) {
+    timings.response = timings.secureConnect;
+  }
+
+  const requestTimings = {
+    dns: timings.lookup - timings.socket,
+    tls: timings.secureConnect - timings.connect,
+    timeToFirstByte: timings.response - timings.secureConnect,
+    download: timings.end - timings.response
+  };
+
+  if (responseContent) {
+    requestTimings.responseSize = Buffer.byteLength(responseContent, ["utf8"]);
+  }
+
+  return requestTimings;
+}
+
+function createRequestOptions(host, path, queryParams, requestOpts) {
+  const { body, headers, agent } = requestOpts;
+  return {
+    method: body ? POST : GET,
+    protocol: SECURE_PROTOCOL,
+    host,
+    path: queryParams ? `${path}${queryParams}` : path,
+    headers,
+    agent: agent || DEFAULT_AGENT
+  };
+}
+
+function executeRequest(options, body, timeout, callback) {
+  const timings = {};
+  const chunks = [];
+  const startTimeNow = now();
+  const request = https.request(options, res => {
+    res.setEncoding(UTF8_ENCODING);
+  });
+  const onLookup = () => {
+    timings.lookup = now() - startTimeNow;
+  };
+  const onConnect = () => {
+    timings.connect = now() - startTimeNow;
+  };
+  const onSecureConnect = () => {
+    timings.secureConnect = now() - startTimeNow;
+  };
+  const onError = err => {
+    callback(creatError(ERROR, err, getTimings(timings)));
+
+    if (request.socket) {
+      request.socket.removeListener(LOOKUP_EVENT, onLookup);
+      request.socket.removeListener(CONNECT_EVENT, onConnect);
+      request.socket.removeListener(SECURE_CONNECT_EVENT, onSecureConnect);
+    }
+  };
+  const onSocket = socket => {
+    timings.socket = now() - startTimeNow;
+
+    if (socket._connecting || socket.connecting) {
+      socket.once(LOOKUP_EVENT, onLookup);
+      socket.once(CONNECT_EVENT, onConnect);
+      socket.once(SECURE_CONNECT_EVENT, onSecureConnect);
+      socket.once(ERROR_EVENT, onError);
+    }
+  };
+  const onResponse = response => {
+    timings.response = now() - startTimeNow;
+
+    response.on(DATA_EVENT, chunk => {
+      chunks.push(chunk);
+    });
+
+    response.once(END_EVENT, () => {
+      const content = chunks.join("");
+      timings.end = now() - startTimeNow;
+
+      if (response.statusCode !== OK && response.statusCode !== NOT_MODIFIED) {
+        callback(
+          creatError(ERROR, content, getTimings(timings), response.statusCode)
+        );
+        return;
+      }
+
+      try {
+        const data = JSON.parse(content);
+        callback(
+          null,
+          createSuccess(
+            data,
+            content,
+            getTimings(timings, content),
+            response.statusCode,
+            response.headers
+          )
+        );
+      } catch (error) {
+        callback(
+          creatError(
+            PARSE_ERROR,
+            error,
+            getTimings(timings),
+            response.statusCode
+          )
+        );
+      }
+    });
+  };
+
+  request.once(RESPONSE_EVENT, onResponse);
+  request.once(SOCKET_EVENT, onSocket);
+  request.once(ABORT_EVENT, () =>
+    callback(creatError(ABORT, ABORTED, getTimings(timings)))
+  );
+  request.once(TIMEOUT_EVENT, () =>
+    callback(creatError(TIMEOUT, TIMED_OUT, getTimings(timings)))
+  );
+  request.once(ERROR_EVENT, onError);
+
+  request.setTimeout(timeout);
+  if (options.method === POST) {
+    request.write(body);
+  }
+  request.end();
+}
+
+/**
+ * Invokes the REST service using the supplied settings and parameters.
+ * @param {String} host The server host.
+ * @param {String} path The base URL to invoke.
+ * @param {Object.<String, Object>} queryParams A map of query parameters and their values.
+ * @param {Object} requestOpts Various request options:  body, headers, timeout, agent
+ * @returns {Promise} A {@link https://www.promisejs.org/|Promise} object.
+ */
+function handleRequest(host, path, queryParams, requestOpts) {
+  const { body, timeout = 10000 } = requestOpts;
+  const options = createRequestOptions(host, path, queryParams, requestOpts);
+  return new Promise((resolve, reject) => {
+    executeRequest(options, body, timeout, (err, response) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+
+      resolve(response);
+    });
+  });
+}
+
+/**
+ * Fetch implementation that uses builtin https module and listens to socket events to capture telemetry data for requests.
+ * The request/response interface align with the browser fetch implementation to preserve cross-compatibility.
+ * @param {String} url The request url
+ * @param {Object} requestOpts Options that can be used to configure the request (optional)
+ * @return {Promise<import("../types/FetchResponse").FetchResponse>}
+ */
+function fetch(url, requestOpts = {}) {
+  const urlObject = new URL(url);
+  const host = urlObject.hostname;
+  const path = urlObject.pathname;
+  const queryParams = urlObject.search;
+  return handleRequest(host, path, queryParams, requestOpts);
+}
+
+export default fetch;

--- a/packages/target-tools/src/fetchWithTelemetry.spec.js
+++ b/packages/target-tools/src/fetchWithTelemetry.spec.js
@@ -100,6 +100,28 @@ describe("fetchWithTelemetry", () => {
     );
   });
 
+  it("sends a valid GET request for .json file", async () => {
+    const writeFn = jest.fn();
+    const mockFetchImpl = getMockFetchImpl(writeFn);
+    const url = "http://myspace.com/friends/export.json";
+
+    mockFetchImpl(url);
+
+    expect(mockRequestImpl).toBeCalledWith(
+      expect.objectContaining({
+        method: "GET",
+        protocol: "http:",
+        host: "myspace.com",
+        path: "/friends/export.json",
+        headers: undefined,
+        agent: expect.any(Object)
+      }),
+      expect.any(Function)
+    );
+
+    expect(writeFn).not.toHaveBeenCalled();
+  });
+
   it("sends a valid GET request using http", async () => {
     const writeFn = jest.fn();
     const mockFetchImpl = getMockFetchImpl(writeFn);

--- a/packages/target-tools/src/fetchWithTelemetry.spec.js
+++ b/packages/target-tools/src/fetchWithTelemetry.spec.js
@@ -1,0 +1,64 @@
+import fetchImpl from "./fetchWithTelemetry";
+
+describe("fetchWithTelemetry", () => {
+  const URL = "https://api.github.com/organizations?per_page=1";
+  const REQUEST_OPTS = {
+    headers: {
+      "Accept": "application/vnd.github.v3+json",
+      "user-agent":
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.77 Safari/537.36"
+    }
+  };
+
+  it("returns request timings on response", async () => {
+    const response = await fetchImpl(URL, REQUEST_OPTS);
+
+    expect(Object.keys(response.timings).length).toBe(5);
+    expect(response.timings).toEqual(
+      expect.objectContaining({
+        dns: expect.any(Number),
+        tls: expect.any(Number),
+        timeToFirstByte: expect.any(Number),
+        download: expect.any(Number),
+        responseSize: expect.any(Number)
+      })
+    );
+  });
+
+  it("formats response to match fetch response to maintain cross-compatibility", async () => {
+    const response = await fetchImpl(URL, REQUEST_OPTS);
+
+    expect(response.data).toEqual(JSON.parse(response.response));
+    expect(response.status).toEqual(200);
+    expect(response.ok).toEqual(true);
+    expect(await response.json()).toEqual(response.data);
+    expect(response.headers).toBeDefined();
+    expect(response.headers.get("Content-Type")).toEqual(
+      expect.stringContaining("application/json")
+    );
+  });
+
+  it("handles http error properly", async () => {
+    const expectedErr = {
+      status: "error",
+      statusCode: 403,
+      message: expect.stringContaining("Request forbidden")
+    };
+
+    await expect(fetchImpl(URL, {})).rejects.toEqual(
+      expect.objectContaining(expectedErr)
+    );
+  });
+
+  it("handles socket-level error properly", async () => {
+    const expectedErr = {
+      status: "error",
+      message: expect.stringContaining("ENOTFOUND"),
+      statusCode: undefined
+    };
+
+    await expect(fetchImpl("http://sx125vz.com/")).rejects.toEqual(
+      expect.objectContaining(expectedErr)
+    );
+  });
+});

--- a/packages/target-tools/src/index.js
+++ b/packages/target-tools/src/index.js
@@ -104,3 +104,5 @@ export { perfTool, createPerfToolInstance } from "./perftool";
 export { default as parseURI } from "parse-uri";
 
 export { default as uuid } from "./uuid";
+
+export { default as defaultFetch } from "./fetchWithTelemetry";

--- a/packages/target-tools/src/index.js
+++ b/packages/target-tools/src/index.js
@@ -105,4 +105,4 @@ export { default as parseURI } from "parse-uri";
 
 export { default as uuid } from "./uuid";
 
-export { default as defaultFetch } from "./fetchWithTelemetry";
+export { default as getFetchWithTelemetry } from "./fetchWithTelemetry";

--- a/packages/target-tools/src/telemetryProvider.spec.js
+++ b/packages/target-tools/src/telemetryProvider.spec.js
@@ -10,7 +10,14 @@ describe("TelemetryProvider", () => {
     notifications: []
   };
   const TARGET_TELEMETRY_ENTRY = {
-    execution: 1
+    execution: 1,
+    request: {
+      dns: 13.205916000000002,
+      tls: 66.416338,
+      timeToFirstByte: 37.84904800000004,
+      download: 0.7802439999999251,
+      responseSize: 241
+    }
   };
   const STATUS_OK = 200;
   const PARTIAL_CONTENT = 206;
@@ -48,7 +55,14 @@ describe("TelemetryProvider", () => {
           prefetchMboxCount: expect.any(Number),
           prefetchViewCount: expect.any(Number)
         },
-        execution: 1
+        execution: 1,
+        request: {
+          dns: expect.any(Number),
+          tls: expect.any(Number),
+          timeToFirstByte: expect.any(Number),
+          download: expect.any(Number),
+          responseSize: expect.any(Number)
+        }
       })
     );
 

--- a/packages/target-tools/types/FetchHeaders.d.ts
+++ b/packages/target-tools/types/FetchHeaders.d.ts
@@ -1,0 +1,6 @@
+export interface FetchHeaders {
+  /**
+   * Function that takes a header name and returns the value of that header
+   */
+  get: Function;
+}

--- a/packages/target-tools/types/FetchResponse.d.ts
+++ b/packages/target-tools/types/FetchResponse.d.ts
@@ -1,0 +1,43 @@
+import { FetchHeaders } from "./FetchHeaders";
+
+export interface FetchResponse {
+  /**
+   * Response content in json format
+   */
+  data: Object;
+
+  /**
+   * Response content in string format
+   */
+  response: String;
+
+  /**
+   * Object containing HTTP request timings for telemetry purposes
+   */
+  timings: Object;
+
+  /**
+   * HTTP status code
+   */
+  status: Number;
+
+  /**
+   * HTTP response headers
+   */
+  headers: FetchHeaders;
+
+  /**
+   * Is the request successful
+   */
+  ok: Boolean;
+
+  /**
+   * Function that returns the response content in json format
+   */
+  json: Function;
+
+  /**
+   * Function that clones the response object
+   */
+  clone: Function;
+}


### PR DESCRIPTION
Replaces node-fetch implementation with a custom fetch implementation that uses the builtin https module.  The https module allows us to listen to socket events so that we can collect timing data for all SDK requests at the socket level (dns, tls handshake, timeToFirstByte, etc).   We will be storing this data for the purpose of SDK telemetry.

## Description
Since the openapi client implementation already allows for a custom fetch implementation to be used I'm simply passing my custom telemetry-enabled implementation in without any changes to the openapi client or models.  However, the ArtifactProvider also uses the same fetch impl.  Since ArtifactProvider is used in the browser it's important for the response from this custom fetch impl to have the same interface as the browser fetch impl. 

The timings themselves are collected via a middleware function that is executed after we receive an http response.  They are added onto the telemetry entry for edge Delivery API requests.  We are not yet collecting request timings when we fetch the ODD artifact (upcoming).

## Motivation and Context
We need to collect low-level http request timing metrics

## How Has This Been Tested?
I've updated and created some new unit tests for this change.  I've also run tests locally (edge and on-device requests) and have verified no regression + inclusion of the timing data in the telemetry entries.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
