### PR TITLE
Update package.json to include the repository

### DIFF
--- a/packages/target-decisioning-engine/package.json
+++ b/packages/target-decisioning-engine/package.json
@@ -25,6 +25,11 @@
     "prepublishOnly": "echo //${NPM_REGISTRY}/:_authToken=${NPM_AUTH_TOKEN} > .npmrc",
     "prepare": "rollup --config"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/adobe/target-nodejs-sdk.git",
+    "directory": "packahes/target-decisioning-engine"
+  },
   "dependencies": {
     "@adobe/target-tools": "^1.5.1",
     "json-logic-js": "^2.0.0"

--- a/packages/target-decisioning-engine/package.json
+++ b/packages/target-decisioning-engine/package.json
@@ -28,7 +28,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/target-nodejs-sdk.git",
-    "directory": "packahes/target-decisioning-engine"
+    "directory": "packages/target-decisioning-engine"
   },
   "dependencies": {
     "@adobe/target-tools": "^1.5.1",

--- a/packages/target-tools/package.json
+++ b/packages/target-tools/package.json
@@ -27,6 +27,11 @@
     "prepublishOnly": "echo //${NPM_REGISTRY}/:_authToken=${NPM_AUTH_TOKEN} > .npmrc",
     "prepare": "rollup --config"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/adobe/target-nodejs-sdk.git",
+    "directory": "packages/target-tools"
+  },
   "dependencies": {
     "@adobe/reactor-object-assign": "^1.0.0",
     "parse-uri": "^1.0.0",


### PR DESCRIPTION
Hi there!
This change adds the repository property to your package.json file(s). Having this available provides a number of benefits to security tooling. For example, it allows for greater trust by checking for signed commits, contributors to a release and validating history with the project. It also allows for comparison between the source code and the published artifact in order to detect attacks on authors during the publication process.
We validate that we're making a PR against the correct repository by comparing the metadata for the published artifact on [npmjs.com](www.npmjs.com) against the metadata in the package.json file in the repository.
This change is provided by a team at Microsoft -- we're happy to answer any questions you may have. (Members of this team include [@s-tuli](https://github.com/s-tuli), [@iarna](https://github.com/iarna), [@v-rr](https://github.com/v-rr), [@v-jiepeng](https://github.com/v-jiepeng), [@v-zhzhou](https://github.com/v-zhzhou) and [@v-gjy](https://github.com/v-gjy)). If you would prefer that we not make these sorts of PRs to projects you maintain, please just say. If you'd like to learn more about what we're doing here, we've prepared a document talking about both this project and some of our other activities around supply chain security here: [microsoft/Secure-Supply-Chain](https://github.com/microsoft/Secure-Supply-Chain)
This PR provides repository metadata for the following packages:
* @adobe/target-decisioning-engine
* @adobe/target-tools

