### PR TITLE
add reactor objects as external for browser build

### DIFF
--- a/packages/target-tools/rollup.config.js
+++ b/packages/target-tools/rollup.config.js
@@ -46,7 +46,7 @@ const browserBabelConfig = {
   ]
 };
 
-const createConfig = (input, file, format, browser) => {
+const createConfig = (input, file, format, browser, external = []) => {
   const plugins = [
     json(),
     resolve(),
@@ -71,6 +71,7 @@ const createConfig = (input, file, format, browser) => {
 
   return {
     input,
+    external,
     output: {
       name: "TargetTools",
       file,
@@ -82,5 +83,11 @@ const createConfig = (input, file, format, browser) => {
 
 export default [
   createConfig("src/index.js", pkg.main, "cjs"),
-  createConfig("src/index.browser.js", pkg.browser, "es")
+  createConfig("src/index.browser.js", pkg.browser, "es", [
+    "@adobe/reactor-object-assign",
+    "@adobe/reactor-cookie",
+    "@adobe/reactor-promise",
+    "@adobe/reactor-query-string",
+    "@adobe/reactor-load-script"
+  ])
 ];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

add `@adobe/reactor-*` dependencies as external in target-tools rollup build to reduce bundle size


launch builds for comparison:


without fix
![screenshot-2021-10-27-153434@2x](https://user-images.githubusercontent.com/427213/139151530-e7dc00b2-7407-47c0-899f-d5c230a98ac3.png)

with fix
![screenshot-2021-10-27-153300@2x](https://user-images.githubusercontent.com/427213/139151552-b46a9e75-1eef-4035-8848-a926e6dd6ee1.png)


