### PR TITLE
fix target-tools createConfig params

### DIFF
--- a/packages/target-tools/rollup.config.js
+++ b/packages/target-tools/rollup.config.js
@@ -46,7 +46,7 @@ const browserBabelConfig = {
   ]
 };
 
-const createConfig = (input, file, format, browser, external = []) => {
+const createConfig = (input, file, format, browser = false) => {
   const plugins = [
     json(),
     resolve(),
@@ -59,7 +59,9 @@ const createConfig = (input, file, format, browser, external = []) => {
       }
     }),
     visualizer({
-      filename: "bundlesize-stats.html"
+      filename: browser
+        ? "bundlesize-stats.browser.html"
+        : "bundlesize-stats.html"
     })
   ];
 
@@ -71,7 +73,15 @@ const createConfig = (input, file, format, browser, external = []) => {
 
   return {
     input,
-    external,
+    external: browser
+      ? [
+          "@adobe/reactor-object-assign",
+          "@adobe/reactor-cookie",
+          "@adobe/reactor-promise",
+          "@adobe/reactor-query-string",
+          "@adobe/reactor-load-script"
+        ]
+      : [],
     output: {
       name: "TargetTools",
       file,
@@ -82,12 +92,6 @@ const createConfig = (input, file, format, browser, external = []) => {
 };
 
 export default [
-  createConfig("src/index.js", pkg.main, "cjs"),
-  createConfig("src/index.browser.js", pkg.browser, "es", [
-    "@adobe/reactor-object-assign",
-    "@adobe/reactor-cookie",
-    "@adobe/reactor-promise",
-    "@adobe/reactor-query-string",
-    "@adobe/reactor-load-script"
-  ])
+  createConfig("src/index.js", pkg.main, "cjs", false),
+  createConfig("src/index.browser.js", pkg.browser, "es", true)
 ];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I realized, after yesterdays PR ( https://github.com/adobe/target-nodejs-sdk/pull/67 ) , that i missed a param in the `createConfig` method call for target-tools.  I had passed in the `external` array where the function was expecting a boolean value for `browser`.  So both builds were treated as browser 😬️. This PR corrects that and also generates a bundle-size html file for both the index and index.browser builds.  That way we can easily see the package breakdown for the bundle.
