### PR TITLE
TNT-41936 - telemetry handling for server state and double digit precision for telemetry decimal values

### DIFF
--- a/packages/target-tools/src/telemetryProvider.js
+++ b/packages/target-tools/src/telemetryProvider.js
@@ -78,6 +78,32 @@ export default function TelemetryProvider(
     return features;
   }
 
+  function normalizeEntryRequest(entryRequest) {
+    const normalized = {};
+
+    if (entryRequest.dns) {
+      normalized.dns = formatDecimal(entryRequest.dns);
+    }
+
+    if (entryRequest.tls) {
+      normalized.tls = formatDecimal(entryRequest.tls);
+    }
+
+    if (entryRequest.timeToFirstByte) {
+      normalized.timeToFirstByte = formatDecimal(entryRequest.timeToFirstByte);
+    }
+
+    if (entryRequest.download) {
+      normalized.download = formatDecimal(entryRequest.download);
+    }
+
+    if (entryRequest.responseSize) {
+      normalized.responseSize = formatDecimal(entryRequest.responseSize);
+    }
+
+    return normalized;
+  }
+
   function normalizeEntry(entry) {
     const normalized = {};
 
@@ -87,6 +113,10 @@ export default function TelemetryProvider(
 
     if (entry.parsing) {
       normalized.parsing = formatDecimal(entry.parsing);
+    }
+
+    if (entry.request) {
+      normalized.request = normalizeEntryRequest(entry.request);
     }
 
     return assign(entry, normalized);

--- a/packages/target-tools/src/telemetryProvider.spec.js
+++ b/packages/target-tools/src/telemetryProvider.spec.js
@@ -80,11 +80,11 @@ describe("TelemetryProvider", () => {
           execution: 1.11,
           parsing: 2.22,
           request: {
-            dns: expect.any(Number),
-            tls: expect.any(Number),
-            timeToFirstByte: expect.any(Number),
-            download: expect.any(Number),
-            responseSize: expect.any(Number)
+            dns: 13.21,
+            tls: 66.42,
+            timeToFirstByte: 37.85,
+            download: 0.78,
+            responseSize: 241
           },
           blob: EDGE_TELEMETRY_BLOB
         })
@@ -210,11 +210,11 @@ describe("TelemetryProvider", () => {
           execution: 1.11,
           parsing: 2.22,
           request: {
-            dns: expect.any(Number),
-            tls: expect.any(Number),
-            timeToFirstByte: expect.any(Number),
-            download: expect.any(Number),
-            responseSize: expect.any(Number)
+            dns: 13.21,
+            tls: 66.42,
+            timeToFirstByte: 37.85,
+            download: 0.78,
+            responseSize: 241
           }
         })
       );

--- a/packages/target-tools/src/telemetryProvider.spec.js
+++ b/packages/target-tools/src/telemetryProvider.spec.js
@@ -2,6 +2,7 @@ import TelemetryProvider from "./telemetryProvider";
 import { DECISIONING_METHOD, EXECUTION_MODE } from "./enums";
 
 describe("TelemetryProvider", () => {
+  const EDGE_TELEMETRY_BLOB = "dsbnoew05vnlsd";
   const TARGET_REQUEST = {
     requestId: "123456",
     execute: {
@@ -18,8 +19,8 @@ describe("TelemetryProvider", () => {
     notifications: []
   };
   const TARGET_TELEMETRY_ENTRY = {
-    execution: 1,
-    parsing: 2,
+    execution: 1.111111,
+    parsing: 2.2222222,
     request: {
       dns: 13.205916000000002,
       tls: 66.416338,
@@ -27,6 +28,10 @@ describe("TelemetryProvider", () => {
       download: 0.7802439999999251,
       responseSize: 241
     }
+  };
+  const EDGE_TELEMETRY_ENTRY = {
+    ...TARGET_TELEMETRY_ENTRY,
+    blob: EDGE_TELEMETRY_BLOB
   };
   const STATUS_OK = 200;
   const PARTIAL_CONTENT = 206;
@@ -37,7 +42,7 @@ describe("TelemetryProvider", () => {
     for (let i = 0; i < 3; i += 1) {
       provider.addDeliveryRequestEntry(
         TARGET_REQUEST,
-        TARGET_TELEMETRY_ENTRY,
+        EDGE_TELEMETRY_ENTRY,
         STATUS_OK
       );
     }
@@ -72,15 +77,16 @@ describe("TelemetryProvider", () => {
             prefetchMboxCount: expect.any(Number),
             prefetchViewCount: expect.any(Number)
           },
-          execution: 1,
-          parsing: 2,
+          execution: 1.11,
+          parsing: 2.22,
           request: {
             dns: expect.any(Number),
             tls: expect.any(Number),
             timeToFirstByte: expect.any(Number),
             download: expect.any(Number),
             responseSize: expect.any(Number)
-          }
+          },
+          blob: EDGE_TELEMETRY_BLOB
         })
       );
     });
@@ -101,7 +107,7 @@ describe("TelemetryProvider", () => {
       expect.objectContaining({
         requestId: TARGET_REQUEST.requestId,
         timestamp: expect.any(Number),
-        execution: 1
+        execution: 1.11
       })
     );
   });
@@ -201,8 +207,8 @@ describe("TelemetryProvider", () => {
         expect.objectContaining({
           requestId,
           timestamp: expect.any(Number),
-          execution: 1,
-          parsing: 2,
+          execution: 1.11,
+          parsing: 2.22,
           request: {
             dns: expect.any(Number),
             tls: expect.any(Number),

--- a/packages/target-tools/src/utils.js
+++ b/packages/target-tools/src/utils.js
@@ -307,3 +307,10 @@ export function prefetchViewCount(request) {
     0
   );
 }
+
+export function formatDecimal(value, digits = 2) {
+  if (!value || !isNumber(value)) {
+    return undefined;
+  }
+  return +value.toFixed(digits);
+}

--- a/packages/target-tools/src/utils.spec.js
+++ b/packages/target-tools/src/utils.spec.js
@@ -18,7 +18,8 @@ import {
   executeMboxCount,
   isPrefetchPageLoad,
   prefetchMboxCount,
-  prefetchViewCount
+  prefetchViewCount,
+  formatDecimal
 } from "./utils";
 import { ChannelType } from "../delivery-api-client";
 import { DECISIONING_METHOD } from "./enums";
@@ -464,5 +465,42 @@ describe("utils", () => {
       })
     ).toEqual(0);
     expect(prefetchViewCount({})).toEqual(0);
+  });
+
+  describe("formatDecimal", () => {
+    it("value is undefined", () => {
+      let value;
+      expect(formatDecimal(value)).toBeUndefined();
+    });
+
+    it("value is not a number", () => {
+      const value = "string";
+      expect(formatDecimal(value)).toBeUndefined();
+    });
+
+    it("value is an integer", () => {
+      const value = 10;
+      expect(formatDecimal(value)).toEqual(10);
+    });
+
+    it("value is a double with more than 2 digits", () => {
+      const value = 10.444;
+      expect(formatDecimal(value)).toEqual(10.44);
+    });
+
+    it("value is a double with more than 2 digits - round up", () => {
+      const value = 10.999;
+      expect(formatDecimal(value)).toEqual(11);
+    });
+
+    it("value is a double with less than 2 digits", () => {
+      const value = 10.3;
+      expect(formatDecimal(value)).toEqual(10.3);
+    });
+
+    it("value is a double and formatted with custom number of digits", () => {
+      const value = 10.999;
+      expect(formatDecimal(value, 3)).toEqual(10.999);
+    });
   });
 });


### PR DESCRIPTION
## Description
- New TelemetryProvider fn for serverState telemetry entries (used by at.js)
- Limit precision for execution and parsing telemetry values to max of 2 fixed decimal digits

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
