### PR TITLE
added sendNotificationError event

### DIFF
--- a/packages/target-decisioning-engine/src/decisionProvider.js
+++ b/packages/target-decisioning-engine/src/decisionProvider.js
@@ -4,6 +4,7 @@ import {
   getPropertyToken,
   isDefined,
   isUndefined,
+  noop,
   objectWithoutUndefinedValues,
   values
 } from "@adobe/target-tools";
@@ -45,6 +46,8 @@ function DecisionProvider(
   logger,
   traceProvider
 ) {
+  const { eventEmitter = noop } = config;
+
   const { responseTokens, rules } = artifact;
   const globalMboxName = artifact.globalMbox || DEFAULT_GLOBAL_MBOX;
 
@@ -63,7 +66,8 @@ function DecisionProvider(
     visitor,
     logger,
     sendNotificationFunc,
-    telemetryEnabled
+    telemetryEnabled,
+    eventEmitter
   );
 
   /**

--- a/packages/target-decisioning-engine/src/events.js
+++ b/packages/target-decisioning-engine/src/events.js
@@ -3,3 +3,4 @@
 export const ARTIFACT_DOWNLOAD_SUCCEEDED = "artifactDownloadSucceeded";
 export const ARTIFACT_DOWNLOAD_FAILED = "artifactDownloadFailed";
 export const GEO_LOCATION_UPDATED = "geoLocationUpdated";
+export const SEND_NOTIFICATION_ERROR = "sendNotificationError";

--- a/packages/target-decisioning-engine/test/decisioning.spec.js
+++ b/packages/target-decisioning-engine/test/decisioning.spec.js
@@ -129,11 +129,16 @@ describe("decisioning engine", () => {
         } else {
           expect(sendNotificationFunc.mock.calls.length).toEqual(1);
           const notificationPayload = sendNotificationFunc.mock.calls[0][0];
-          notificationPayload.request = telemetryProvider.addTelemetryToDeliveryRequest(
-            notificationPayload.request
-          );
 
-          expectToMatchObject(notificationPayload, notificationOutput);
+          expectToMatchObject(
+            {
+              ...notificationPayload,
+              request: telemetryProvider.addTelemetryToDeliveryRequest(
+                notificationPayload.request
+              )
+            },
+            notificationOutput
+          );
         }
       }
     });

--- a/packages/target-decisioning-engine/test/decisioning.spec.js
+++ b/packages/target-decisioning-engine/test/decisioning.spec.js
@@ -1,10 +1,11 @@
 /* eslint-disable jest/no-conditional-expect */
 import * as MockDate from "mockdate";
 import {
+  DECISIONING_METHOD,
   isDefined,
   isUndefined,
-  TelemetryProvider,
-  DECISIONING_METHOD
+  noopPromise,
+  TelemetryProvider
 } from "@adobe/target-tools";
 
 import TargetDecisioningEngine from "../src";
@@ -73,7 +74,7 @@ describe("decisioning engine", () => {
       ]);
 
     test.each(TESTS)("%s", async (testDescription, suiteData, testData) => {
-      const sendNotificationFunc = jest.fn();
+      const sendNotificationFunc = jest.fn(noopPromise);
 
       const { input, output, notificationOutput, mockDate, mockGeo } = testData;
 
@@ -128,10 +129,9 @@ describe("decisioning engine", () => {
         } else {
           expect(sendNotificationFunc.mock.calls.length).toEqual(1);
           const notificationPayload = sendNotificationFunc.mock.calls[0][0];
-          notificationPayload.request =
-            telemetryProvider.addTelemetryToDeliveryRequest(
-              notificationPayload.request
-            );
+          notificationPayload.request = telemetryProvider.addTelemetryToDeliveryRequest(
+            notificationPayload.request
+          );
 
           expectToMatchObject(notificationPayload, notificationOutput);
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When using ODD in the node SDK, notifications will be automatically sent.  But if those notifications fail for some reason, there is no way to catch them or see the errors easily.

This PR adds a new event called `sendNotificationError` that can be used to listen for errors when sending notifications. 

Sample code for how to use:

```javascript
const TargetClient = require("@adobe/target-nodejs-sdk");
let client;

function onSendNotificationError({notification, error}) {
  console.log(
    `There was an error when sending a notification: ${error.message}`
  );
  console.log(`Notification Payload: ${JSON.stringify(notification, null, 2)}`);
}

async function targetClientReady() {
  const payload = {}; //imagine this is a real request
  const targetResponse = await client.getOffers(payload);
}

client = TargetClient.create({
  events: {
    clientReady: targetClientReady
    sendNotificationError: onSendNotificationError
  }
});
```

## Related Issue

https://jira.corp.adobe.com/browse/TNT-45232

## How Has This Been Tested?

unit tests added, existing tests updated.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


