### PR TITLE
TNT-45619 params with dots do not work - Node SDK and at.js

### DIFF
--- a/packages/target-decisioning-engine/src/contextProvider.js
+++ b/packages/target-decisioning-engine/src/contextProvider.js
@@ -96,26 +96,40 @@ export function createReferringContext(address) {
 }
 
 /**
- * @param { import("../types/DecisioningContext").MboxContext }
+ * @param @param { import("../types/DecisioningContext").MboxContext } context
+ * @param { string } key
+ * @param { object } value
+ * @return { import("../types/DecisioningContext").MboxContext }
+ */
+function addNestedKeyToParameters(context, key, value) {
+  const result = context;
+  let currentObj = result;
+  const keys = key.split(".");
+  for (let i = 0; i < keys.length - 1; i += 1) {
+    currentObj[keys[i]] = currentObj[keys[i]] || {};
+    currentObj = currentObj[keys[i]];
+  }
+  currentObj[keys[keys.length - 1]] = value;
+  return result;
+}
+
+/**
+ * @param { import("../types/DecisioningContext").MboxContext } context
  * @return { import("../types/DecisioningContext").MboxContext }
  */
 function createNestedParametersFromDots(context) {
-  const result = {};
+  let result = {};
   Object.keys(context).forEach(key => {
-    // eslint-disable-next-line no-restricted-properties
-    if (key.includes(".") && !key.includes("..")) {
-      const keys = key.split(".");
-      let currentObj = result;
-      for (let i = 0; i < keys.length - 1; i += 1) {
-        if (!(keys[i] in currentObj)) {
-          currentObj[keys[i]] = {};
-        }
-        currentObj = currentObj[keys[i]];
-      }
-      currentObj[keys[keys.length - 1]] = context[key];
-    } else {
-      result[key] = context[key];
+    if (
+      key.indexOf(".") > -1 &&
+      key.indexOf("..") === -1 &&
+      key[0] !== "." &&
+      key[key.length - 1] !== "."
+    ) {
+      result = addNestedKeyToParameters(result, key, context[key]);
+      return;
     }
+    result[key] = context[key];
   });
   return result;
 }

--- a/packages/target-decisioning-engine/src/contextProvider.js
+++ b/packages/target-decisioning-engine/src/contextProvider.js
@@ -124,7 +124,6 @@ function createNestedParametersFromDots(context) {
  * @param { import("@adobe/target-tools/delivery-api-client/models/MboxRequest").MboxRequest } mboxRequest
  * @return { import("../types/DecisioningContext").MboxContext }
  */
-// FIXME
 export function createMboxContext(mboxRequest) {
   if (!mboxRequest) {
     return {};

--- a/packages/target-decisioning-engine/src/contextProvider.spec.js
+++ b/packages/target-decisioning-engine/src/contextProvider.spec.js
@@ -333,6 +333,39 @@ describe("contextProvider", () => {
     expect(createMboxContext(undefined)).toEqual({});
   });
 
+  it("supports mbox content with dot notation", () => {
+    expect(
+      createMboxContext({
+        index: 10,
+        name: "dot_mbox",
+        parameters: {
+          "favorite.pizza": "PINEAPPLE",
+          "favorite.month": "august",
+          "ignore..notation": true,
+          "support.nested.notation": true,
+          "support.nested.dots": true
+        }
+      })
+    ).toEqual({
+      "favorite": {
+        pizza: "PINEAPPLE",
+        pizza_lc: "pineapple",
+        month: "august",
+        month_lc: "august"
+      },
+      "ignore..notation": true,
+      "ignore..notation_lc": true,
+      "support": {
+        nested: {
+          notation: true,
+          notation_lc: true,
+          dots: true,
+          dots_lc: true
+        }
+      }
+    });
+  });
+
   it("produces geo context", () => {
     expect(
       createGeoContext({

--- a/packages/target-decisioning-engine/src/contextProvider.spec.js
+++ b/packages/target-decisioning-engine/src/contextProvider.spec.js
@@ -343,7 +343,9 @@ describe("contextProvider", () => {
           "favorite.month": "august",
           "ignore..notation": true,
           "support.nested.notation": true,
-          "support.nested.dots": true
+          "support.nested.dots": true,
+          ".best.coast": "east",
+          "trailing.dots.": "bad"
         }
       })
     ).toEqual({
@@ -355,6 +357,14 @@ describe("contextProvider", () => {
       },
       "ignore..notation": true,
       "ignore..notation_lc": true,
+      ".best.coast": "east",
+      ".best.coast_lc": "east",
+      "trailing.dots.": "bad",
+      "trailing": {
+        dots: {
+          _lc: "bad"
+        }
+      },
       "support": {
         nested: {
           notation: true,

--- a/packages/target-decisioning-engine/test/schema/artifacts/TEST_ARTIFACT_PARAMS.json
+++ b/packages/target-decisioning-engine/test/schema/artifacts/TEST_ARTIFACT_PARAMS.json
@@ -130,6 +130,43 @@
             ],
             "metrics": []
           }
+        },
+        {
+          "ruleKey": "125874",
+          "activityId": 125874,
+          "meta": {
+            "activity.id": 125874,
+            "activity.name": "[unit-test] mbox-params",
+            "activity.type": "ab",
+            "experience.id": 2,
+            "experience.name": "Experience C",
+            "location.name": "mbox-params",
+            "location.type": "mbox",
+            "location.id": 0,
+            "audience.ids": [1821805],
+            "offer.id": 246851,
+            "offer.name": "/_unit-test_mbox-params/experiences/1/pages/0/zones/0/1612386851213",
+            "option.id": 3,
+            "option.name": "Offer3"
+          },
+          "condition": {
+            "and": [
+              { "==": ["racket", { "var": "mbox.first.programming.language" }] },
+              { "==": ["red", { "var": "mbox.favorite.color" }] },
+              { "==": ["the big lebowski", { "var": "mbox.favorite.movie" }] }
+            ]
+          },
+          "consequence": {
+            "name": "mbox-params",
+            "options": [
+              {
+                "type": "json",
+                "eventToken": "gsDuhGuCbuMhKLusIlPUI5NWHtnQtQrJfmRrQugEa2qCnQ9Y9OaLL2gsdrWQTvE54PwSz67rmXWmSnkXpSSS2Q==",
+                "content": { "foo": "bar", "fizz": "buzz", "experience": "C" }
+              }
+            ],
+            "metrics": []
+          }
         }
       ]
     },

--- a/packages/target-decisioning-engine/test/schema/models/TEST_SUITE_PARAMS.json
+++ b/packages/target-decisioning-engine/test/schema/models/TEST_SUITE_PARAMS.json
@@ -115,6 +115,68 @@
           ]
         }
       }
+    },
+    "mbox_params_with_dots": {
+      "description": "supports matching params with dot notation",
+      "input": {
+        "request": {
+          "id": {
+            "tntId": "338e3c1e51f7416a8e1ccba4f81acea0.28_0",
+            "marketingCloudVisitorId": "07327024324407615852294135870030620007"
+          },
+          "context": {
+            "channel": "web",
+            "mobilePlatform": null,
+            "application": null,
+            "screen": null,
+            "window": null,
+            "browser": null,
+            "address": {
+              "url": "http://local-target-test:8080/home?fabulous=true#sosumi",
+              "referringUrl": null
+            },
+            "geo": null,
+            "timeOffsetInMinutes": null,
+            "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:73.0) Gecko/20100101 Firefox/73.0",
+            "beacon": false
+          },
+          "prefetch": {
+            "mboxes": [
+              {
+                "name": "mbox-params",
+                "parameters": {
+                  "first.programming.language": "racket",
+                  "favorite.color": "red",
+                  "favorite.movie": "the big lebowski"
+                },
+                "index": 1
+              }
+            ]
+          }
+        },
+        "sessionId": "dummy_session"
+      },
+      "output": {
+        "prefetch": {
+          "mboxes": [
+            {
+              "index": 1,
+              "name": "mbox-params",
+              "options": [
+                {
+                  "type": "json",
+                  "content": {
+                    "foo": "bar",
+                    "fizz": "buzz",
+                    "experience": "C"
+                  },
+                  "eventToken": "gsDuhGuCbuMhKLusIlPUI5NWHtnQtQrJfmRrQugEa2qCnQ9Y9OaLL2gsdrWQTvE54PwSz67rmXWmSnkXpSSS2Q=="
+                }
+              ]
+            }
+          ]
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Ticket for reference: https://jira.corp.adobe.com/browse/TNT-45619

Customer created rules that contain dot notation (ex: favorite.color) are now transformed into nested JSON objects so that they can be correctly processed by JsonLogic. 

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
