### PR TITLE
Fix(webpack5): Should not import named export from default-exporting module

### DIFF
--- a/packages/target-nodejs-sdk/src/helper.js
+++ b/packages/target-nodejs-sdk/src/helper.js
@@ -54,7 +54,7 @@ import {
   SESSION_ID_COOKIE
 } from "./cookies";
 
-import { version } from "../package.json";
+import packageInfo from "../package.json";
 
 import {
   executeSendBeacon,
@@ -85,6 +85,7 @@ const HOST = "tt.omtrdc.net";
 const SESSION_ID_MAX_AGE = 1860;
 const DEVICE_ID_MAX_AGE = 63244800;
 const LOCATION_HINT_MAX_AGE = 1860;
+const PACKAGE_VERSION = packageInfo.version;
 
 DeliveryApi.prototype.decisioningMethod = DECISIONING_METHOD.SERVER_SIDE;
 
@@ -156,7 +157,7 @@ export function createHeaders(uuidMethod = uuid) {
   return {
     "Content-Type": "application/json",
     "X-EXC-SDK": "AdobeTargetNode",
-    "X-EXC-SDK-Version": version,
+    "X-EXC-SDK-Version": PACKAGE_VERSION,
     "X-Request-Id": uuidMethod()
   };
 }


### PR DESCRIPTION
## Description

Trying to import the `@adobe/target-nodejs-sdk` lib in an Angular 14 lib for use in server side testing results in 

```
Should not import the named export 'version' (imported as 'version') from default-exporting module (only default export is available soon)
```

A quick Google search lead me to [this issue in the AWS SDK](https://github.com/aws/aws-sdk-js-v3/issues/1504).

Tl:dr; webpack 5 doesn't like named imports from default exported modules e.g., `import {version} from '../package.json'`

## Motivation and Context

Fixes `@adobe/target-nodejs-sdk` for webpack5 users.

## How Has This Been Tested?

Built, tarballed, and installed locally and verified this fixed the issue for me.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
