### PR TITLE
Configure adobe bot ssh token during checkout step

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          ssh-key: ${{ secrets.ADOBE_BOT_GITHUB_TOKEN }}
       - name: Configure git user for release commits
         run: |
           git config user.email "Grp-opensourceoffice@adobe.com"
@@ -25,8 +26,6 @@ jobs:
           node-version: 14
           registry-url: "https://registry.npmjs.org"
       - name: Publish to registry.npmjs.org
-        with:
-          token: ${{ secrets.ADOBE_BOT_GITHUB_TOKEN }}
         run: |
           npm ci
           npm run publish ${{ github.event.inputs.semverBump }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adding the Adobe bot token to the `Publish to registry.npmjs.org` did not circumvent the push protection issue. Adding the `ssh-key` parameter while checking out out the branch in an attempt to persist the Adobe bot credentials while avoiding the original username issue. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
