### PR TITLE
Add TargetClient.TargetQAModeCookieName

### DIFF
--- a/packages/target-nodejs-sdk/src/cookies.js
+++ b/packages/target-nodejs-sdk/src/cookies.js
@@ -14,6 +14,7 @@ export const TARGET_COOKIE = "mbox";
 export const SESSION_ID_COOKIE = "session";
 export const DEVICE_ID_COOKIE = "PC";
 export const LOCATION_HINT_COOKIE = "mboxEdgeCluster";
+export const QA_MODE_COOKIE = "at_qa_mode";
 
 function createInternalCookie(name, value, expires) {
   return { name, value, expires };

--- a/packages/target-nodejs-sdk/src/index.js
+++ b/packages/target-nodejs-sdk/src/index.js
@@ -27,7 +27,7 @@ import Visitor from "@adobe-mcid/visitor-js-server";
 import TargetDecisioningEngine from "@adobe/target-decisioning-engine";
 import { createVisitor } from "./utils";
 import { Messages } from "./messages";
-import { LOCATION_HINT_COOKIE, TARGET_COOKIE } from "./cookies";
+import { LOCATION_HINT_COOKIE, TARGET_COOKIE, QA_MODE_COOKIE } from "./cookies";
 import { executeDelivery } from "./target";
 import { preserveLocationHint, requestLocationHintCookie } from "./helper";
 
@@ -263,6 +263,10 @@ export default function bootstrap(fetchApi) {
 
     static get TargetLocationHintCookieName() {
       return LOCATION_HINT_COOKIE;
+    }
+
+    static get TargetQaModeCookieName() {
+      return QA_MODE_COOKIE;
     }
 
     static get AuthState() {

--- a/packages/target-nodejs-sdk/test/index.spec.js
+++ b/packages/target-nodejs-sdk/test/index.spec.js
@@ -121,6 +121,10 @@ describe("Target Client factory", () => {
     );
   });
 
+  it("should return qa mode cookie name", () => {
+    expect(TargetClient.TargetQaModeCookieName).toBe("at_qa_mode");
+  });
+
   it("should return Visitor Auth State", () => {
     expect(TargetClient.AuthState).toEqual(AUTH_STATE);
   });


### PR DESCRIPTION
## Description

There are already convenient getters on `TargetClient` for getting other AT cookie names. This adds the "at_qa_mode" cookie name as a constant.


## Related Issue

Closes #114.

## Motivation and Context

Provide a good developer experience. Adds similar interface for accessing QA Mode Cookie name as already exists with other Adobe Target cookies.

## How Has This Been Tested?

Added a unit test.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
