### PR TITLE
Support custom environment name

### DIFF
--- a/packages/target-decisioning-engine/src/artifactProvider.spec.js
+++ b/packages/target-decisioning-engine/src/artifactProvider.spec.js
@@ -1,6 +1,5 @@
 import * as HttpStatus from "http-status-codes";
 import {
-  ENVIRONMENT_PROD,
   ENVIRONMENT_STAGE,
   isDefined,
   TelemetryProvider
@@ -10,8 +9,7 @@ import * as constants from "./constants";
 import {
   ARTIFACT_FORMAT_DEFAULT,
   ARTIFACT_FORMAT_JSON,
-  CDN_BASE_PROD,
-  CDN_BASE_STAGE,
+  CDN_BASE_PATH,
   SUPPORTED_ARTIFACT_MAJOR_VERSION
 } from "./constants";
 import Messages from "./messages";
@@ -400,7 +398,7 @@ describe("determineArtifactLocation", () => {
         cdnEnvironment: "staging"
       })
     ).toEqual(
-      `https://${CDN_BASE_STAGE}/someClientId/production/v${SUPPORTED_ARTIFACT_MAJOR_VERSION}/rules.json`
+      `https://${CDN_BASE_PATH}/someClientId/production/v${SUPPORTED_ARTIFACT_MAJOR_VERSION}/rules.json`
     );
   });
 
@@ -410,7 +408,7 @@ describe("determineArtifactLocation", () => {
         client: "someClientId"
       })
     ).toEqual(
-      `https://${CDN_BASE_PROD}/someClientId/production/v${SUPPORTED_ARTIFACT_MAJOR_VERSION}/rules.json`
+      `https://${CDN_BASE_PATH}/someClientId/production/v${SUPPORTED_ARTIFACT_MAJOR_VERSION}/rules.json`
     );
   });
 
@@ -421,7 +419,7 @@ describe("determineArtifactLocation", () => {
         artifactFormat: "bin"
       })
     ).toEqual(
-      `https://${CDN_BASE_PROD}/someClientId/production/v${SUPPORTED_ARTIFACT_MAJOR_VERSION}/rules.bin`
+      `https://${CDN_BASE_PATH}/someClientId/production/v${SUPPORTED_ARTIFACT_MAJOR_VERSION}/rules.bin`
     );
   });
 
@@ -432,7 +430,7 @@ describe("determineArtifactLocation", () => {
         artifactFormat: "wonk"
       })
     ).toEqual(
-      `https://${CDN_BASE_PROD}/someClientId/production/v${SUPPORTED_ARTIFACT_MAJOR_VERSION}/rules.${ARTIFACT_FORMAT_DEFAULT}`
+      `https://${CDN_BASE_PATH}/someClientId/production/v${SUPPORTED_ARTIFACT_MAJOR_VERSION}/rules.${ARTIFACT_FORMAT_DEFAULT}`
     );
   });
 
@@ -443,26 +441,18 @@ describe("determineArtifactLocation", () => {
         environment: ENVIRONMENT_STAGE
       })
     ).toEqual(
-      `https://${CDN_BASE_PROD}/someClientId/${ENVIRONMENT_STAGE}/v${SUPPORTED_ARTIFACT_MAJOR_VERSION}/rules.json`
+      `https://${CDN_BASE_PATH}/someClientId/${ENVIRONMENT_STAGE}/v${SUPPORTED_ARTIFACT_MAJOR_VERSION}/rules.json`
     );
   });
 
-  it("warns on invalid environment name and defaults to prod", done => {
+  it("warns on invalid environment name and defaults to prod", () => {
     expect(
       determineArtifactLocation({
         client: "someClientId",
-        environment: "boohoo",
-        logger: {
-          debug: (prefix, message) => {
-            expect(message).toEqual(
-              Messages.INVALID_ENVIRONMENT("boohoo", ENVIRONMENT_PROD)
-            );
-            done();
-          }
-        }
+        environment: "1-PROD"
       })
     ).toEqual(
-      `https://${CDN_BASE_PROD}/someClientId/${ENVIRONMENT_PROD}/v${SUPPORTED_ARTIFACT_MAJOR_VERSION}/rules.json`
+      `https://${CDN_BASE_PATH}/someClientId/1-prod/v${SUPPORTED_ARTIFACT_MAJOR_VERSION}/rules.json`
     );
   });
 
@@ -473,7 +463,7 @@ describe("determineArtifactLocation", () => {
         propertyToken: "xyz-123-abc"
       })
     ).toEqual(
-      `https://${CDN_BASE_PROD}/someClientId/production/v${SUPPORTED_ARTIFACT_MAJOR_VERSION}/xyz-123-abc/rules.json`
+      `https://${CDN_BASE_PATH}/someClientId/production/v${SUPPORTED_ARTIFACT_MAJOR_VERSION}/xyz-123-abc/rules.json`
     );
   });
 });

--- a/packages/target-decisioning-engine/src/constants.js
+++ b/packages/target-decisioning-engine/src/constants.js
@@ -1,9 +1,3 @@
-import {
-  ENVIRONMENT_DEV,
-  ENVIRONMENT_PROD,
-  ENVIRONMENT_STAGE
-} from "@adobe/target-tools";
-
 export const DEFAULT_POLLING_INTERVAL = 300000; // five minutes (in milliseconds)
 export const MINIMUM_POLLING_INTERVAL = 300000; // five minutes (in milliseconds)
 export const NUM_FETCH_RETRIES = 10;
@@ -21,9 +15,7 @@ ARTIFACT_FILENAME[ARTIFACT_FORMAT_JSON] = "rules.json";
 
 export const LOG_PREFIX = "LD";
 
-export const CDN_BASE_PROD = "assets.adobetarget.com";
-export const CDN_BASE_STAGE = "assets.staging.adobetarget.com";
-export const CDN_BASE_DEV = "assets.staging.adobetarget.com";
+export const CDN_BASE_PATH = "assets.adobetarget.com";
 
 export const HTTP_HEADER_FORWARDED_FOR = "x-forwarded-for";
 export const HTTP_HEADER_GEO_LATITUDE = "x-geo-latitude";
@@ -31,14 +23,6 @@ export const HTTP_HEADER_GEO_LONGITUDE = "x-geo-longitude";
 export const HTTP_HEADER_GEO_COUNTRY = "x-geo-country-code";
 export const HTTP_HEADER_GEO_REGION = "x-geo-region-code";
 export const HTTP_HEADER_GEO_CITY = "x-geo-city";
-
-const CDN_BASE = {};
-CDN_BASE[ENVIRONMENT_PROD] = CDN_BASE_PROD;
-CDN_BASE[ENVIRONMENT_STAGE] = CDN_BASE_STAGE;
-CDN_BASE[ENVIRONMENT_DEV] = CDN_BASE_DEV;
-
-export { CDN_BASE };
-
 export const CAMPAIGN_BUCKET_SALT = "0";
 
 // Response token keys

--- a/packages/target-decisioning-engine/src/geoProvider.js
+++ b/packages/target-decisioning-engine/src/geoProvider.js
@@ -8,14 +8,15 @@ import {
   UNKNOWN_IP_ADDRESS
 } from "@adobe/target-tools";
 import { GEO_LOCATION_UPDATED } from "./events";
-import { getGeoLookupPath } from "./utils";
 import {
+  CDN_BASE_PATH,
   HTTP_HEADER_FORWARDED_FOR,
   HTTP_HEADER_GEO_CITY,
   HTTP_HEADER_GEO_COUNTRY,
   HTTP_HEADER_GEO_LATITUDE,
   HTTP_HEADER_GEO_LONGITUDE,
-  HTTP_HEADER_GEO_REGION
+  HTTP_HEADER_GEO_REGION,
+  SUPPORTED_ARTIFACT_MAJOR_VERSION
 } from "./constants";
 
 const GEO_MAPPINGS = [
@@ -108,7 +109,7 @@ export function GeoProvider(config, artifact) {
     }
 
     // When ipAddress is the only geo value passed in to getOffers(), do IP-to-Geo lookup.
-    const geoLookupPath = getGeoLookupPath(config);
+    const geoLookupPath = `https://${CDN_BASE_PATH}/v${SUPPORTED_ARTIFACT_MAJOR_VERSION}/geo`;
 
     if (
       geoTargetingEnabled &&


### PR DESCRIPTION
We have made changes to support custom environment name as in the Target UI under Administration > Environments. 
The default environment is set to production.

For CDN, we are always pointing to assets.adobetarget.com, aligning with our Java SDK implementation.
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
